### PR TITLE
FIX always keep case for relation labels

### DIFF
--- a/educe/rst_dt/deptree.py
+++ b/educe/rst_dt/deptree.py
@@ -217,7 +217,7 @@ def relaxed_nuclearity_from_deptree(dtree, multinuclear):
         The target of a dep tree link is normally the satellite
         unless the relation is marked multinuclear
         """
-        return _N if rel.lower() in multinuclear else _S
+        return _N if rel in multinuclear else _S
 
     def mk_leaf(dnode):
         """

--- a/educe/rst_dt/util/cmd/reltypes.py
+++ b/educe/rst_dt/util/cmd/reltypes.py
@@ -30,9 +30,9 @@ def walk_and_count(tree, counts):
     "Count relation types in tree, incrementing values in `counts`"
 
     if tree.label().is_nucleus():
-        counts.multi[tree.label().rel.lower()] += 1
+        counts.multi[tree.label().rel] += 1
     elif tree.label().is_satellite():
-        counts.mono[tree.label().rel.lower()] += 1
+        counts.mono[tree.label().rel] += 1
     for child in tree:
         if not isinstance(child, educe.rst_dt.EDU):
             walk_and_count(child, counts)


### PR DESCRIPTION
The RST-DT manual implies (pp. 42--44) that case in relation labels is meaningful.

Educe was using lowercase in two places:
- counting relation types,
- conversion from dependency to "phrase"-ish tree.

@kowey please remember to keep this on hold until we discuss the need for relaxed nuclearity with higher wisdom, as this proposal effectively cancels relaxed nuclearity out.
