### PR TITLE
FIX rename Span.len() to Span.length()

### DIFF
--- a/educe/annotation.py
+++ b/educe/annotation.py
@@ -57,7 +57,7 @@ class Span(object):
     def __hash__(self):
         return (self.char_start, self.char_end).__hash__()
 
-    def len(self):
+    def length(self):
         """
         Return the length of this span
         """

--- a/educe/graph.py
+++ b/educe/graph.py
@@ -941,7 +941,7 @@ class EnclosureGraph(dgr.digraph, AttrsMixin):
             self.add_node(node)
             for x in attrs.items():
                 self.add_node_attribute(node,x)
-            of_width[spans[anno].len()].append(anno)
+            of_width[spans[anno].length()].append(anno)
 
         narrow = []
         for width in sorted(of_width):


### PR DESCRIPTION
`len` is a reserved method name, usually implemented as `__len__(self)` and called as `len(x)`.
A minimal fix is to rename Span.len() to Span.length().
