### PR TITLE
FIX basket feature extraction with missing PTB data

### DIFF
--- a/educe/learning/keys.py
+++ b/educe/learning/keys.py
@@ -267,7 +267,7 @@ class KeyGroup(dict):
         Value corresponding to a single key.
         """
         value = self[key.name]
-        if key.substance is Substance.BASKET:
+        if (key.substance is Substance.BASKET) and (value is not None):
             return " ".join("{0}={1}".format(k,v) for k,v in value.items())
         else:
             return value

--- a/educe/rst_dt/learning/features.py
+++ b/educe/rst_dt/learning/features.py
@@ -377,7 +377,7 @@ def ptb_pos_tag_first_pairs(_, cache, edu):
 def ptb_pos_tags_in_first(current, edu1, _):
     "demonstrator for use of basket features"
     tokens = current.ptb_tokens[edu1]
-    return Counter(t.tag for t in tokens)
+    return Counter(t.tag for t in tokens) if tokens is not None else None
 
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
Feature extraction of basket features crashes in the absence of corresponding PTB tokens and trees.

@kowey I has some trouble finding this bug, so you might want to reproduce it on your system to confirm the bug beforehand.

I was running  ̀irit-rst-dt gather`with the default parameters, e.g.
`TRAINING_CORPORA = ['corpus/RSTtrees-WSJ-double-1.0']`.
Failure was happening on`file4`, which goes by another name in the PTB.
