### PR TITLE
FIX unigram feat ptb_pos_tag_last

### DIFF
--- a/educe/rst_dt/learning/features.py
+++ b/educe/rst_dt/learning/features.py
@@ -247,7 +247,7 @@ def ptb_pos_tag_first(token):
 
 
 @ptb_tokens_feature
-@on_last_bigram
+@on_last_unigram
 def ptb_pos_tag_last(token):
     "POS tag for last PTB token in the EDU"
     # note: PTB tokens may not necessarily correspond to words


### PR DESCRIPTION
The feature `ptb_pos_tag_last` was erroneously computed as a bigram instead of unigram feature.
