### PR TITLE
Left padding sentence and paragraph for fake root EDU

### DIFF
--- a/educe/rst_dt/learning/base.py
+++ b/educe/rst_dt/learning/base.py
@@ -404,7 +404,9 @@ def _surrounding_text(edu):
     Reuben Mark, chief executive of Colgate-Palmolive, said...
     """
     if edu.is_left_padding():
-        return Paragraph.left_padding(), Sentence.left_padding()
+        sent = Sentence.left_padding()
+        para = Paragraph.left_padding([sent])
+        return para, sent
     # normal case
     espan = edu.text_span()
     para = _filter0(containing(espan), edu.context.paragraphs)

--- a/educe/rst_dt/text.py
+++ b/educe/rst_dt/text.py
@@ -18,6 +18,32 @@ objects (paragraphs and sentences)
 from educe.annotation import Standoff, Span
 
 
+class Paragraph(Standoff):
+    """
+    A paragraph is a sequence of `Sentence`s (also standoff
+    annotations).
+    """
+    def __init__(self, num, sentences):
+        self.sentences = sentences
+        "sentence-level annotations"
+
+        self.num = num
+        "paragraph ID in document"
+
+        super(Paragraph, self).__init__()
+
+    def _members(self):
+        return self.sentences
+
+    # left padding
+    _lpad_num = -1
+
+    @classmethod
+    def left_padding(cls, sentences):
+        """Return a left padding Paragraph"""
+        return cls(cls._lpad_num, sentences)
+
+
 class Sentence(Standoff):
     """
     Just a text span really
@@ -38,35 +64,8 @@ class Sentence(Standoff):
 
     @classmethod
     def left_padding(cls):
-        """Return a left padding Paragraph"""
+        """Return a left padding Sentence"""
         return cls(cls._lpad_num, cls._lpad_span)
-
-
-class Paragraph(Standoff):
-    """
-    A paragraph is a sequence of `Sentence`s (also standoff
-    annotations).
-    """
-    def __init__(self, num, sentences):
-        self.sentences = sentences
-        "sentence-level annotations"
-
-        self.num = num
-        "paragraph ID in document"
-
-        super(Paragraph, self).__init__()
-
-    def _members(self):
-        return self.sentences
-
-    # left padding
-    _lpad_num = -1
-    _lpad_sentences = [Sentence.left_padding()]
-
-    @classmethod
-    def left_padding(cls):
-        """Return a left padding Paragraph"""
-        return cls(cls._lpad_num, cls._lpad_sentences)
 
 
 def parse_text(text):


### PR DESCRIPTION
The fake root did not have any sentence nor paragraph, which means many values were missing in the relevant instances.
This PR adds left padding sentence and paragraph and associates them to the left padding EDU that is the fake root.
