### PR TITLE
FIX do not use itertools.repeat

### DIFF
--- a/educe/rst_dt/deptree.py
+++ b/educe/rst_dt/deptree.py
@@ -411,11 +411,6 @@ class RstDepTree(object):
             real_root = roots[0][1]  # roots is a list of (label, num)
             rparts = walk(None, real_root, strategy)
         else:
-            print('edus: {}'.format(self.edus))
-            print('heads: {}'.format(self.heads))
-            print('labels: {}'.format(self.labels))
-            print('deps: {}'.format(', '.join(str(d)
-                                              for d in self.deps)))
             msg = ('Cannot convert RstDepTree to SimpleRSTTree, ',
                    'multiple roots: {}'.format(roots))
             raise RstDtException(msg)


### PR DESCRIPTION
`itertools.repeat` returns references to the same object, whereas we need distinct objects so that updates do not affect all of them.
