### PR TITLE
[MRG + 1] stac-edit

### DIFF
--- a/docs/api-doc/educe.stac.rst
+++ b/docs/api-doc/educe.stac.rst
@@ -11,6 +11,7 @@ Subpackages
 
 .. toctree::
 
+    educe.stac.edit
     educe.stac.learning
     educe.stac.lexicon
     educe.stac.oneoff

--- a/educe/annotation.py
+++ b/educe/annotation.py
@@ -170,6 +170,9 @@ class Span(object):
         Return a span that stretches from the beginning to the end
         of all the spans in the list
         """
+        spans = list(spans)
+        if len(spans) < 1:
+            raise ValueError("must have at least one span")
         big_start = min(x.char_start for x in spans)
         big_end = max(x.char_end for x in spans)
         return Span(big_start, big_end)

--- a/educe/stac/edit/cmd/__init__.py
+++ b/educe/stac/edit/cmd/__init__.py
@@ -14,6 +14,7 @@ from . import (delete_anno,
                nudge_dialogue,
                rename,
                rewrite,
+               split_dialogue,
                split_edu)
 
 # at the time of this writing argparse doesn't support a way to group
@@ -28,6 +29,7 @@ SUBCOMMAND_SECTIONS =\
      ('Boundaries',
       [merge_dialogue,
        merge_edus,
+       split_dialogue,
        split_edu,
        nudge,
        nudge_dialogue]),

--- a/educe/stac/edit/cmd/__init__.py
+++ b/educe/stac/edit/cmd/__init__.py
@@ -1,0 +1,37 @@
+"""
+stac-edit subcommands
+"""
+
+# Author: Eric Kow
+# License: CeCILL-B (French BSD3)
+
+from . import (insert,
+               merge_dialogue,
+               merge_edus,
+               move,
+               nudge,
+               nudge_dialogue,
+               rename,
+               rewrite,
+               split_edu)
+
+# at the time of this writing argparse doesn't support a way to group
+# subcommands into sections, but maybe we can wait for it to grow such
+# a feature, or write our own formatter class, or just abuse the command
+# epilog
+SUBCOMMAND_SECTIONS =\
+    [('Editing',
+      [rename,
+       rewrite,
+       merge_dialogue,
+       merge_edus,
+       split_edu,
+       nudge,
+       nudge_dialogue]),
+     ('Advanced editing',
+      [insert,
+       move])]
+
+SUBCOMMANDS = []
+for descr, section in SUBCOMMAND_SECTIONS:
+    SUBCOMMANDS.extend(section)

--- a/educe/stac/edit/cmd/__init__.py
+++ b/educe/stac/edit/cmd/__init__.py
@@ -21,16 +21,17 @@ from . import (delete_anno,
 # a feature, or write our own formatter class, or just abuse the command
 # epilog
 SUBCOMMAND_SECTIONS =\
-    [('Editing',
+    [('Annotation ids',
       [rename,
        delete_anno,
-       rewrite,
-       merge_dialogue,
+       rewrite]),
+     ('Boundaries',
+      [merge_dialogue,
        merge_edus,
        split_edu,
        nudge,
        nudge_dialogue]),
-     ('Advanced editing',
+     ('Block editing',
       [insert,
        move])]
 

--- a/educe/stac/edit/cmd/__init__.py
+++ b/educe/stac/edit/cmd/__init__.py
@@ -5,7 +5,8 @@ stac-edit subcommands
 # Author: Eric Kow
 # License: CeCILL-B (French BSD3)
 
-from . import (insert,
+from . import (delete_anno,
+               insert,
                merge_dialogue,
                merge_edus,
                move,
@@ -22,6 +23,7 @@ from . import (insert,
 SUBCOMMAND_SECTIONS =\
     [('Editing',
       [rename,
+       delete_anno,
        rewrite,
        merge_dialogue,
        merge_edus,

--- a/educe/stac/edit/cmd/delete_anno.py
+++ b/educe/stac/edit/cmd/delete_anno.py
@@ -107,6 +107,6 @@ def main(args):
         doc = corpus[key]
         _delete_in_doc(args.anno_id, doc)
         save_document(output_dir, key, doc)
-    pretty_id = anno_id_from_tuple(anno_id)
+    pretty_id = anno_id_from_tuple(args.anno_id)
     print("Deleted %s" % pretty_id, file=sys.stderr)
     announce_output_dir(output_dir)

--- a/educe/stac/edit/cmd/delete_anno.py
+++ b/educe/stac/edit/cmd/delete_anno.py
@@ -36,7 +36,9 @@ def _delete_in_doc(del_id, doc):
     matches = [x for x in doc.annotations() if not is_ok(x)]
 
     if not matches:
-        sys.exit("No annotations found with id %s" % pretty_id)
+        print("Skipping... no annotations found with id %s" % pretty_id,
+              file=sys.stderr)
+        return
     elif len(matches) > 1:
         sys.exit("Huh?! More than one annotation with id %s" % pretty_id)
 

--- a/educe/stac/edit/cmd/delete_anno.py
+++ b/educe/stac/edit/cmd/delete_anno.py
@@ -14,25 +14,13 @@ from educe.stac.util.glozz import anno_id_from_tuple, anno_id_to_tuple
 from educe.stac.util.output import save_document
 
 
-
-def _is_match(wanted):
-    """
-    Given an annotation id, return a predicate that checks if
-    an annotation id matches
-    """
-    def pred(anno):
-        "curried second arg"
-        return anno_id_to_tuple(anno.local_id()) == wanted
-    return pred
-
-
 def _delete_in_doc(del_id, doc):
     """Delete the annotations with the given id in the given document
 
     NB: modifies doc
     """
     pretty_id = anno_id_from_tuple(del_id)
-    is_ok = lambda x: not _is_match(del_id)(x)
+    is_ok = lambda x: anno_id_to_tuple(x.local_id()) != del_id
     matches = [x for x in doc.annotations() if not is_ok(x)]
 
     if not matches:

--- a/educe/stac/edit/cmd/delete_anno.py
+++ b/educe/stac/edit/cmd/delete_anno.py
@@ -1,0 +1,110 @@
+# Author: Eric Kow
+# License: CeCILL-B (French BSD3-like)
+
+"""Delete an annotation"""
+
+from __future__ import print_function
+import sys
+
+from educe.stac.util.args import\
+    add_usual_input_args, add_usual_output_args,\
+    read_corpus, get_output_dir, announce_output_dir,\
+    anno_id
+from educe.stac.util.glozz import anno_id_from_tuple, anno_id_to_tuple
+from educe.stac.util.output import save_document
+
+
+
+def _is_match(wanted):
+    """
+    Given an annotation id, return a predicate that checks if
+    an annotation id matches
+    """
+    def pred(anno):
+        "curried second arg"
+        return anno_id_to_tuple(anno.local_id()) == wanted
+    return pred
+
+
+def _delete_in_doc(del_id, doc):
+    """Delete the annotations with the given id in the given document
+
+    NB: modifies doc
+    """
+    pretty_id = anno_id_from_tuple(del_id)
+    is_ok = lambda x: not _is_match(del_id)(x)
+    matches = [x for x in doc.annotations() if not is_ok(x)]
+
+    if not matches:
+        sys.exit("No annotations found with id %s" % pretty_id)
+    elif len(matches) > 1:
+        sys.exit("Huh?! More than one annotation with id %s" % pretty_id)
+
+    doc.units = [x for x in doc.units if is_ok(x)]
+    doc.relations = [x for x in doc.relations if is_ok(x)]
+    doc.schemas = [x for x in doc.schemas if is_ok(x)]
+
+    def oops(reason):
+        "quit because of illegal delete"
+        sys.exit("Can't delete %s because %s " % pretty_id, reason)
+
+    for anno in doc.relations:
+        if anno.span.t1 == pretty_id:
+            oops("it is the source for a relation: %s" % anno)
+        if anno.span.t2 == pretty_id:
+            oops("it is the target for a relation: %s" % anno)
+    for anno in doc.schemas:
+        if pretty_id in anno.units:
+            oops("it is a unit member of %s" % anno)
+        if pretty_id in anno.relations:
+            oops("it is a relation member of %s" % anno)
+        if pretty_id in anno.schemas:
+            oops("it is a schema member of %s" % anno)
+
+# ---------------------------------------------------------------------
+# command and options
+# ---------------------------------------------------------------------
+
+NAME = 'delete-anno'
+
+
+def config_argparser(parser):
+    """
+    Subcommand flags.
+
+    You should create and pass in the subparser to which the flags
+    are to be added.
+    """
+    add_usual_input_args(parser, doc_subdoc_required=True)
+    add_usual_output_args(parser, default_overwrite=True)
+    parser.add_argument('anno_id', type=anno_id, metavar='ANNO_ID',
+                        help='id to rename (eg. kowey_398190)')
+    parser.add_argument('--stage', metavar='STAGE',
+                        choices=['discourse', 'units', 'unannotated'])
+    parser.add_argument('--annotator', metavar='STRING')
+    parser.set_defaults(func=main)
+
+
+def main(args):
+    """
+    Subcommand main.
+
+    You shouldn't need to call this yourself if you're using
+    `config_argparser`
+    """
+    if args.stage:
+        if args.stage != 'unannotated' and not args.annotator:
+            sys.exit("--annotator is required unless --stage is unannotated")
+        elif args.stage == 'unannotated' and args.annotator:
+            sys.exit("--annotator is forbidden if --stage is unannotated")
+    output_dir = get_output_dir(args, default_overwrite=True)
+    corpus = read_corpus(args, verbose=True)
+
+    for key in corpus:
+        print(key)
+        doc = corpus[key]
+        _delete_in_doc(args.anno_id, doc)
+        save_document(output_dir, key, doc)
+    pretty_id = anno_id_from_tuple(anno_id)
+    print("Deleted %s" % pretty_id, file=sys.stderr)
+    announce_output_dir(output_dir)

--- a/educe/stac/edit/cmd/insert.py
+++ b/educe/stac/edit/cmd/insert.py
@@ -34,7 +34,7 @@ def config_argparser(parser):
     """
     add_usual_input_args(parser, doc_subdoc_required=True,
                          help_suffix='to insert into')
-    add_usual_output_args(parser)
+    add_usual_output_args(parser, default_overwrite=True)
     parser.add_argument('insert', metavar='DIR',
                         help='dir with just one pair of .aa/.ac files')
     parser.add_argument('start', metavar='INT', type=int,
@@ -49,7 +49,7 @@ def main(args):
     You shouldn't need to call this yourself if you're using
     `config_argparser`
     """
-    output_dir = get_output_dir(args)
+    output_dir = get_output_dir(args, default_overwrite=True)
 
     src_reader = educe.stac.LiveInputReader(args.insert)
     src_corpus = src_reader.slurp(src_reader.files())

--- a/educe/stac/edit/cmd/insert.py
+++ b/educe/stac/edit/cmd/insert.py
@@ -10,21 +10,20 @@ import sys
 
 import educe.stac
 
-from ..annotate import show_diff
-from ..args import\
-    add_usual_input_args, add_usual_output_args,\
-    get_output_dir, announce_output_dir
-from ..output import save_document
-from ..doc import\
+from educe.stac.util.annotate import show_diff
+from educe.stac.util.args import\
+    (add_usual_input_args,
+     add_usual_output_args,
+     announce_output_dir,
+     get_output_dir)
+from educe.stac.util.output import save_document
+from educe.stac.util.doc import\
     compute_renames, move_portion
-from ..cmd.move import is_requested
+from .move import is_requested
 
 # ---------------------------------------------------------------------
 # command and options
 # ---------------------------------------------------------------------
-
-NAME = 'insert'
-
 
 def config_argparser(parser):
     """

--- a/educe/stac/edit/cmd/merge_dialogue.py
+++ b/educe/stac/edit/cmd/merge_dialogue.py
@@ -154,7 +154,7 @@ def commit_msg(args, corpus, k, sought):
     we are about to do (has to be run before merging happens)
     """
     doc = corpus[k]
-    dstr = ", ".join(map(anno_id_from_tuple, sought))
+    dstr = ", ".join(anno_id_from_tuple(x) for x in sought)
     dialogues = [_get_annotation_with_id(d, doc.units) for d in sought]
     if dialogues:
         title_fmt = u"{doc}_{subdoc}: merge dialogues{hint}"
@@ -190,7 +190,7 @@ def main(args):
             if len(sought) < 2:
                 sys.exit("Must specify at least two dialogues")
             print("Merging dialogues: " +
-                  ", ".join(map(anno_id_from_tuple, sought)),
+                  ", ".join(anno_id_from_tuple(x) for x in sought),
                   file=sys.stderr)
         except GlozzException as oops:
             sys.exit(str(oops))

--- a/educe/stac/edit/cmd/merge_dialogue.py
+++ b/educe/stac/edit/cmd/merge_dialogue.py
@@ -134,7 +134,7 @@ def config_argparser(parser):
     """
     add_usual_input_args(parser, doc_subdoc_required=True,
                          help_suffix='in which to merge')
-    add_usual_output_args(parser)
+    add_usual_output_args(parser, default_overwrite=True)
     parser_mutex = parser.add_mutually_exclusive_group(required=True)
     parser_mutex.add_argument('--dialogues',
                               metavar='ANNO_ID', type=anno_id,
@@ -182,7 +182,7 @@ def main(args):
 
     if not args.turns and len(args.dialogues) < 2:
         sys.exit("Must specify at least two dialogues")
-    output_dir = get_output_dir(args)
+    output_dir = get_output_dir(args, default_overwrite=True)
     corpus = read_corpus(args, verbose=True)
     if args.turns:
         try:

--- a/educe/stac/edit/cmd/merge_dialogue.py
+++ b/educe/stac/edit/cmd/merge_dialogue.py
@@ -12,16 +12,16 @@ import sys
 from educe.annotation import Span
 from educe.glozz import GlozzException
 
-from ..annotate import annotate_doc
-from ..args import\
+from educe.stac.util.annotate import annotate_doc
+from educe.stac.util.args import\
     add_usual_input_args, add_usual_output_args, anno_id,\
     add_commit_args,\
     read_corpus,\
     get_output_dir, announce_output_dir
-from ..glozz import\
+from educe.stac.util.glozz import\
     anno_id_from_tuple, anno_id_to_tuple,\
     get_turn, is_dialogue
-from ..output import save_document
+from educe.stac.util.output import save_document
 
 
 def _get_annotation_with_id(sought_tuple, annotations):

--- a/educe/stac/edit/cmd/merge_edus.py
+++ b/educe/stac/edit/cmd/merge_edus.py
@@ -50,7 +50,7 @@ def config_argparser(parser):
     parser.add_argument('--span', metavar='SPAN', type=comma_span,
                         required=True,
                         help='eg. 347,363')
-    add_usual_output_args(parser)
+    add_usual_output_args(parser, default_overwrite=True)
     add_commit_args(parser)
     parser.set_defaults(func=main)
 
@@ -191,7 +191,7 @@ def main(args):
     """
     corpus = read_corpus_with_unannotated(args)
     tcache = TimestampCache()
-    output_dir = get_output_dir(args)
+    output_dir = get_output_dir(args, default_overwrite=True)
     commit_info = None
     for k in corpus:
         old_doc = corpus[k]

--- a/educe/stac/edit/cmd/merge_edus.py
+++ b/educe/stac/edit/cmd/merge_edus.py
@@ -13,18 +13,20 @@ import sys
 from educe.stac.context import (edus_in_span)
 import educe.stac
 
-from ..annotate import show_diff, annotate_doc
-from ..glozz import (TimestampCache, set_anno_author, set_anno_date)
-from ..args import\
+from educe.stac.util.annotate import show_diff, annotate_doc
+from educe.stac.util.glozz import (TimestampCache,
+                                   set_anno_author,
+                                   set_anno_date)
+from educe.stac.util.args import\
     add_usual_input_args,\
     add_usual_output_args,\
     add_commit_args,\
     read_corpus_with_unannotated,\
     get_output_dir, announce_output_dir,\
     comma_span
-from ..doc import\
+from educe.stac.util.doc import\
     narrow_to_span, enclosing_span, retarget
-from ..output import save_document
+from educe.stac.util.output import save_document
 from .split_edu import\
     _AUTHOR, _SPLIT_PREFIX
 

--- a/educe/stac/edit/cmd/merge_edus.py
+++ b/educe/stac/edit/cmd/merge_edus.py
@@ -10,6 +10,7 @@ from collections import namedtuple
 import copy
 import sys
 
+from educe.annotation import (Span)
 from educe.stac.context import (edus_in_span)
 import educe.stac
 
@@ -25,7 +26,7 @@ from educe.stac.util.args import\
     get_output_dir, announce_output_dir,\
     comma_span
 from educe.stac.util.doc import\
-    narrow_to_span, enclosing_span, retarget
+    narrow_to_span, retarget
 from educe.stac.util.output import save_document
 from .split_edu import\
     _AUTHOR, _SPLIT_PREFIX
@@ -78,7 +79,7 @@ def _actually_merge(tcache, edus, doc):
     if not edus:
         return
     new_edu = copy.deepcopy(edus[0])
-    new_edu.span = enclosing_span([x.text_span() for x in edus])
+    new_edu.span = Span.merge_all(x.text_span() for x in edus)
     stamp = tcache.get(new_edu.span)
     set_anno_date(new_edu, stamp)
     set_anno_author(new_edu, _AUTHOR)
@@ -117,7 +118,7 @@ def _merge_edus(tcache, span, doc):
     if not edus:
         sys.exit("No EDUs in span %s" % span)
 
-    espan = enclosing_span([x.text_span() for x in edus])
+    espan = Span.merge_all(x.text_span() for x in edus)
     if espan != span:
         sys.exit("EDUs in do not cover full span %s [only %s]" %
                  (span, espan))

--- a/educe/stac/edit/cmd/move.py
+++ b/educe/stac/edit/cmd/move.py
@@ -101,6 +101,7 @@ def main(args):
     for src_k in src_corpus:
         tgt_k = copy.copy(src_k)
         tgt_k.subdoc = args.target
+        print(src_k, tgt_k, file=sys.stderr)
         if tgt_k not in tgt_corpus:
             sys.exit("Uh-oh! we don't have %s in the corpus" % tgt_k)
         else:

--- a/educe/stac/edit/cmd/move.py
+++ b/educe/stac/edit/cmd/move.py
@@ -11,7 +11,6 @@ from __future__ import print_function
 import copy
 import sys
 
-from educe.annotation import Span
 import educe.stac
 
 from educe.stac.util.annotate import show_diff

--- a/educe/stac/edit/cmd/move.py
+++ b/educe/stac/edit/cmd/move.py
@@ -75,7 +75,7 @@ def config_argparser(parser):
     """
     add_usual_input_args(parser, doc_subdoc_required=True,
                          help_suffix='to move from')
-    add_usual_output_args(parser)
+    add_usual_output_args(parser, default_overwrite=True)
     parser.add_argument('start', metavar='INT', type=int,
                         help='Text span start')
     parser.add_argument('end', metavar='INT', type=int,
@@ -91,7 +91,7 @@ def main(args):
     You shouldn't need to call this yourself if you're using
     `config_argparser`
     """
-    output_dir = get_output_dir(args)
+    output_dir = get_output_dir(args, default_overwrite=True)
     if args.start != 0:
         sys.exit("Sorry, only know how to deal with start=0 at the moment")
 

--- a/educe/stac/edit/cmd/move.py
+++ b/educe/stac/edit/cmd/move.py
@@ -14,12 +14,12 @@ import sys
 from educe.annotation import Span
 import educe.stac
 
-from ..annotate import show_diff
-from ..args import\
+from educe.stac.util.annotate import show_diff
+from educe.stac.util.args import\
     add_usual_input_args, add_usual_output_args,\
     get_output_dir, announce_output_dir
-from ..doc import compute_renames, move_portion
-from ..output import save_document
+from educe.stac.util.doc import compute_renames, move_portion
+from educe.stac.util.output import save_document
 
 
 def is_target(args):

--- a/educe/stac/edit/cmd/nudge.py
+++ b/educe/stac/edit/cmd/nudge.py
@@ -19,7 +19,7 @@ from educe.stac.util.args import\
      add_commit_args,
      comma_span,
      read_corpus, get_output_dir, announce_output_dir)
-from educe.stac.util.doc import narrow_to_span, enclosing_span
+from educe.stac.util.doc import narrow_to_span
 from educe.stac.util.output import save_document
 
 
@@ -32,8 +32,7 @@ def _enclosing_turn_span(doc, span):
         "enclosing turn"
         return educe.stac.is_turn(anno) and anno.text_span().encloses(span)
     spans = [span] + [u.text_span() for u in doc.units if is_match(u)]
-    return Span(min(x.char_start for x in spans),
-                max(x.char_end for x in spans))
+    return Span.merge_all(spans)
 
 
 def _is_nudge(offset):
@@ -181,7 +180,7 @@ def main(args):
                   file=sys.stderr)
         save_document(output_dir, k, new_doc)
         # for commit message generation
-        span = enclosing_span([old_span, new_span])
+        span = old_span.merge(new_span)
         commit_info = CommitInfo(key=k,
                                  before=old_doc,
                                  after=new_doc,

--- a/educe/stac/edit/cmd/nudge.py
+++ b/educe/stac/edit/cmd/nudge.py
@@ -74,7 +74,7 @@ def config_argparser(parser):
     are to be added.
     """
     add_usual_input_args(parser, doc_subdoc_required=True)
-    add_usual_output_args(parser)
+    add_usual_output_args(parser, default_overwrite=True)
     add_commit_args(parser)
     parser.add_argument('start', metavar='INT', type=int,
                         help='text span start')
@@ -161,7 +161,7 @@ def main(args):
     """
     _screen_args(args)
     corpus = read_corpus(args, verbose=True)
-    output_dir = get_output_dir(args)
+    output_dir = get_output_dir(args, default_overwrite=True)
 
     old_span = Span(args.start, args.end)
     new_span = Span(args.start + args.nudge_start,

--- a/educe/stac/edit/cmd/nudge.py
+++ b/educe/stac/edit/cmd/nudge.py
@@ -15,9 +15,10 @@ import educe.stac
 
 from educe.stac.util.annotate import show_diff, annotate_doc
 from educe.stac.util.args import\
-    add_usual_input_args, add_usual_output_args,\
-    add_commit_args,\
-    read_corpus, get_output_dir, announce_output_dir
+    (add_usual_input_args, add_usual_output_args,
+     add_commit_args,
+     comma_span,
+     read_corpus, get_output_dir, announce_output_dir)
 from educe.stac.util.doc import narrow_to_span, enclosing_span
 from educe.stac.util.output import save_document
 
@@ -76,10 +77,8 @@ def config_argparser(parser):
     add_usual_input_args(parser, doc_subdoc_required=True)
     add_usual_output_args(parser, default_overwrite=True)
     add_commit_args(parser)
-    parser.add_argument('start', metavar='INT', type=int,
-                        help='text span start')
-    parser.add_argument('end', metavar='INT', type=int,
-                        help='text span end')
+    parser.add_argument('span', metavar='INT,INT', type=comma_span,
+                        help='text span')
     parser.add_argument('nudge_start', metavar='INT', type=int,
                         help='adjust start [-1 to 1]')
     parser.add_argument('nudge_end', metavar='INT', type=int,
@@ -163,9 +162,9 @@ def main(args):
     corpus = read_corpus(args, verbose=True)
     output_dir = get_output_dir(args, default_overwrite=True)
 
-    old_span = Span(args.start, args.end)
-    new_span = Span(args.start + args.nudge_start,
-                    args.end + args.nudge_end)
+    old_span = args.span
+    new_span = Span(old_span.char_start + args.nudge_start,
+                    old_span.char_end + args.nudge_end)
     for k in corpus:
         old_doc = corpus[k]
         new_doc = copy.deepcopy(old_doc)

--- a/educe/stac/edit/cmd/nudge.py
+++ b/educe/stac/edit/cmd/nudge.py
@@ -13,13 +13,13 @@ import sys
 from educe.annotation import Span
 import educe.stac
 
-from ..annotate import show_diff, annotate_doc
-from ..args import\
+from educe.stac.util.annotate import show_diff, annotate_doc
+from educe.stac.util.args import\
     add_usual_input_args, add_usual_output_args,\
     add_commit_args,\
     read_corpus, get_output_dir, announce_output_dir
-from ..doc import narrow_to_span, enclosing_span
-from ..output import save_document
+from educe.stac.util.doc import narrow_to_span, enclosing_span
+from educe.stac.util.output import save_document
 
 
 def _enclosing_turn_span(doc, span):

--- a/educe/stac/edit/cmd/nudge_dialogue.py
+++ b/educe/stac/edit/cmd/nudge_dialogue.py
@@ -114,14 +114,14 @@ def _nudge_dialogue(doc, tid, direction):
     """
     prev_turn, turn, next_turn = \
         _window1(lambda x: st.turn_id(x) == tid,
-                 filter(st.is_turn, doc.units))
+                 [x for x in doc.units if st.is_turn(x)])
     if not turn:
         sys.exit("Could not find turn %d" % tid)
 
     tspan = turn.text_span()
     prev_dialogue, dialogue, next_dialogue = \
         _window1(lambda x: x.text_span().encloses(tspan),
-                 filter(st.is_dialogue, doc.units))
+                 [x for x in doc.units if st.is_dialogue(x)])
 
     if direction == "up":
         return _nudge_up(turn, dialogue, next_turn, prev_dialogue)

--- a/educe/stac/edit/cmd/nudge_dialogue.py
+++ b/educe/stac/edit/cmd/nudge_dialogue.py
@@ -13,13 +13,13 @@ import sys
 from educe.annotation import Span
 import educe.stac as st
 
-from ..annotate import show_diff, annotate_doc
-from ..args import\
+from educe.stac.util.annotate import show_diff, annotate_doc
+from educe.stac.util.args import\
     add_usual_input_args, add_usual_output_args,\
     add_commit_args,\
     read_corpus, get_output_dir, announce_output_dir
-from ..doc import narrow_to_span
-from ..output import save_document
+from educe.stac.util.doc import narrow_to_span
+from educe.stac.util.output import save_document
 
 
 def _mini_diff(k, args, old_doc, new_doc, span):

--- a/educe/stac/edit/cmd/nudge_dialogue.py
+++ b/educe/stac/edit/cmd/nudge_dialogue.py
@@ -88,9 +88,10 @@ def _nudge_down(turn, dialogue, prev_turn, next_dialogue):
 
 
 def _window1(pred, annos):
-    """
-    Return window of prev, match, next, where next is the item matching
-    the predicate.  All values could be None
+    """Return window of prev, match, next, where match is the item matching
+    the predicate.
+
+    All values could be None:
 
     * prev None if match is the first item
     * match None if no match (prev/next should by rights be None too)

--- a/educe/stac/edit/cmd/nudge_dialogue.py
+++ b/educe/stac/edit/cmd/nudge_dialogue.py
@@ -146,7 +146,7 @@ def config_argparser(parser):
     are to be added.
     """
     add_usual_input_args(parser, doc_subdoc_required=True)
-    add_usual_output_args(parser)
+    add_usual_output_args(parser, default_overwrite=True)
     add_commit_args(parser)
     parser.add_argument('turn', metavar='TURN', type=int,
                         help='turn number')
@@ -182,7 +182,7 @@ def main(args):
     `config_argparser`
     """
     corpus = read_corpus(args, verbose=True)
-    output_dir = get_output_dir(args)
+    output_dir = get_output_dir(args, default_overwrite=True)
 
     for k in corpus:
         print(k)

--- a/educe/stac/edit/cmd/rename.py
+++ b/educe/stac/edit/cmd/rename.py
@@ -8,13 +8,13 @@ Rename an annotation
 from __future__ import print_function
 import sys
 
-from ..args import\
+from educe.stac.util.args import\
     add_usual_input_args, add_usual_output_args,\
     read_corpus, get_output_dir, announce_output_dir,\
     anno_id
-from ..doc import compute_renames, evil_set_id
-from ..glozz import anno_id_from_tuple, anno_id_to_tuple
-from ..output import save_document
+from educe.stac.util.doc import compute_renames, evil_set_id
+from educe.stac.util.glozz import anno_id_from_tuple, anno_id_to_tuple
+from educe.stac.util.output import save_document
 
 
 def _is_match(wanted):

--- a/educe/stac/edit/cmd/rename.py
+++ b/educe/stac/edit/cmd/rename.py
@@ -32,7 +32,7 @@ def _has_named_annotation(target, doc):
     """
     Return True if the given document has the target annotation
     """
-    return bool(filter(_is_match(target), doc.annotations()))
+    return any(_is_match(target)(x) for x in  doc.annotations())
 
 
 def _get_target(args, source, corpus):
@@ -64,7 +64,7 @@ def _rename_in_doc(source, target, doc):
 
     NB: modifies doc
     """
-    matches = list(filter(_is_match(source), doc.annotations()))
+    matches = [x for x in doc.annotations() if _is_match(source)(x)]
     pretty_source = anno_id_from_tuple(source)
     pretty_target = anno_id_from_tuple(target)
     target_author, target_date = target

--- a/educe/stac/edit/cmd/rename.py
+++ b/educe/stac/edit/cmd/rename.py
@@ -17,17 +17,6 @@ from educe.stac.util.glozz import anno_id_from_tuple, anno_id_to_tuple
 from educe.stac.util.output import save_document
 
 
-def _is_match(wanted):
-    """
-    Given an annotation id, return a predicate that checks if
-    an annotation id matches
-    """
-    def pred(anno):
-        "curried second arg"
-        return anno_id_to_tuple(anno.local_id()) == wanted
-    return pred
-
-
 def _has_named_annotation(target, doc):
     """
     Return True if the given document has the target annotation

--- a/educe/stac/edit/cmd/rename.py
+++ b/educe/stac/edit/cmd/rename.py
@@ -32,7 +32,8 @@ def _has_named_annotation(target, doc):
     """
     Return True if the given document has the target annotation
     """
-    return any(_is_match(target)(x) for x in  doc.annotations())
+    return any(anno_id_to_tuple(x.local_id()) == target
+               for x in  doc.annotations())
 
 
 def _get_target(args, source, corpus):
@@ -64,7 +65,8 @@ def _rename_in_doc(source, target, doc):
 
     NB: modifies doc
     """
-    matches = [x for x in doc.annotations() if _is_match(source)(x)]
+    matches = [x for x in doc.annotations() if
+               anno_id_to_tuple(x.local_id()) == source]
     pretty_source = anno_id_from_tuple(source)
     pretty_target = anno_id_from_tuple(target)
     target_author, target_date = target

--- a/educe/stac/edit/cmd/rename.py
+++ b/educe/stac/edit/cmd/rename.py
@@ -104,7 +104,7 @@ def config_argparser(parser):
     are to be added.
     """
     add_usual_input_args(parser, doc_subdoc_required=True)
-    add_usual_output_args(parser)
+    add_usual_output_args(parser, default_overwrite=True)
     parser.add_argument('--stage', metavar='STAGE',
                         choices=['discourse', 'units', 'unannotated'])
     parser.add_argument('--annotator', metavar='STRING')
@@ -128,7 +128,7 @@ def main(args):
             sys.exit("--annotator is required unless --stage is unannotated")
         elif args.stage == 'unannotated' and args.annotator:
             sys.exit("--annotator is forbidden if --stage is unannotated")
-    output_dir = get_output_dir(args)
+    output_dir = get_output_dir(args, default_overwrite=True)
     corpus = read_corpus(args, verbose=True)
 
     source = args.source

--- a/educe/stac/edit/cmd/rewrite.py
+++ b/educe/stac/edit/cmd/rewrite.py
@@ -61,7 +61,7 @@ def config_argparser(parser):
     parser_mutex.add_argument('--overwrite-input', action='store_true',
                               help='save results back to input dir')
     parser.add_argument('--output', '-o', metavar='DIR',
-                        help='output directory (default mktemp)')
+                        help='output directory (default overwrite!)')
     parser.set_defaults(func=main)
 
 
@@ -73,7 +73,7 @@ def main(args):
     `config_argparser`
     """
     corpus = read_corpus(args, verbose=True)
-    output_dir = get_output_dir(args)
+    output_dir = get_output_dir(args, default_overwrite=True)
     for k in corpus:
         doc = corpus[k]
         if args.diff_friendly:

--- a/educe/stac/edit/cmd/rewrite.py
+++ b/educe/stac/edit/cmd/rewrite.py
@@ -36,7 +36,7 @@ def _diff_friendly(annos):
     requested, but in order for that to work we have to to eliminate spurious
     diffs that would obscure the interesting bits.
     """
-    return sorted_first_widest(map(_sans_modified_by, annos))
+    return sorted_first_widest(_sans_modified_by(x) for x in  annos)
 
 # ---------------------------------------------------------------------
 # command and args

--- a/educe/stac/edit/cmd/rewrite.py
+++ b/educe/stac/edit/cmd/rewrite.py
@@ -8,11 +8,11 @@ Read and write back without changing anything else; potentially reformats XML
 
 import copy
 
-from ..args import\
+from educe.stac.util.args import\
     add_usual_input_args,\
     read_corpus,\
     get_output_dir, announce_output_dir
-from ..output import save_document
+from educe.stac.util.output import save_document
 from educe.stac.context import sorted_first_widest
 
 

--- a/educe/stac/edit/cmd/split_dialogue.py
+++ b/educe/stac/edit/cmd/split_dialogue.py
@@ -1,0 +1,173 @@
+# Author: Eric Kow
+# License: CeCILL-B (French BSD3-like)
+
+"""Split a dialogue annotation into two
+
+Warning: the second dialogue annotation will have no
+trades or dicerolls
+"""
+
+from __future__ import print_function
+from collections import namedtuple
+import copy
+import sys
+
+from educe.annotation import Span
+import educe.stac as st
+
+from educe.stac.util.annotate import show_diff, annotate_doc
+from educe.stac.util.args import\
+    add_usual_input_args, add_usual_output_args,\
+    add_commit_args,\
+    read_corpus, get_output_dir, announce_output_dir
+from educe.stac.util.glozz import\
+    (TimestampCache,
+     set_anno_author, set_anno_date)
+from educe.stac.util.doc import narrow_to_span
+from educe.stac.util.output import save_document
+
+_AUTHOR = 'stacutil'
+
+def _mini_diff(k, args, old_doc, new_doc, span):
+    """
+    Return lines of text to be printed out, showing how the nudge
+    affected the text
+    """
+    mini_old_doc = narrow_to_span(old_doc, span)
+    mini_new_doc = narrow_to_span(new_doc, span)
+    return ["======= SPLIT AT TURN %d in %s ========" %
+            (args.turn, k),
+            "...",
+            show_diff(mini_old_doc, mini_new_doc),
+            "...",
+            ""]
+
+
+def _set(tcache, span, anno):
+    """Assign an annotation an id/span according to the timestamp cache"""
+    stamp = tcache.get(span)
+    set_anno_date(anno, stamp)
+    set_anno_author(anno, _AUTHOR)
+    anno.span = span
+
+
+def _actually_split(tcache, doc, dialogue, turn):
+    """Split the dialogue before the given turn.
+    """
+    dspan = dialogue.text_span()
+    tspan = turn.text_span()
+    span1 = Span(dspan.char_start, tspan.char_start - 1)
+    span2 = Span(tspan.char_start - 1, dspan.char_end)
+    dialogue1 = dialogue
+    dialogue2 = copy.deepcopy(dialogue)
+    _set(tcache, span1, dialogue1)
+    _set(tcache, span2, dialogue2)
+    doc.units.append(dialogue2)
+    dialogue2.features = {}
+
+
+def _the(desc, items):
+    """Return the first element of a sequence if it's a singleton
+
+    Die if there are none or more than one
+    """
+    items = list(items)
+    if not items:
+        sys.exit("Could not find " + desc)
+    elif len(items) > 1:
+        sys.exit("Found more than one " + desc + " (%d)" % len(items))
+    else:
+        return items[0]
+
+
+def _split_dialogue(tcache, doc, tid):
+    """Split a dialogue at a turn
+
+    Turns at or after the given tid are pushed into a new empty
+    dialogue.
+
+    Returns
+    -------
+    Span for the dialogue that was split
+    """
+
+    wanted_t = 'turn %d' % tid
+    wanted_d = 'dialogue for ' + wanted_t
+    turn = _the(wanted_t, [x for x in doc.units if st.is_turn(x) and
+                           st.turn_id(x) == tid])
+    dialogue = _the(wanted_d, [x for x in doc.units if st.is_dialogue(x) and
+                               x.encloses(turn)])
+    dspan = dialogue.text_span()
+    _actually_split(tcache, doc, dialogue, turn)
+    return dspan
+
+
+# ---------------------------------------------------------------------
+#
+# ---------------------------------------------------------------------
+
+NAME = 'split-dialogue'
+
+
+def config_argparser(parser):
+    """
+    Subcommand flags.
+
+    You should create and pass in the subparser to which the flags
+    are to be added.
+    """
+    add_usual_input_args(parser, doc_subdoc_required=True)
+    add_usual_output_args(parser, default_overwrite=True)
+    add_commit_args(parser)
+    parser.add_argument('turn', metavar='TURN', type=int,
+                        help='turn number')
+    parser.set_defaults(func=main)
+
+
+CommitInfo = namedtuple("CommitTuple", "key before after span tid")
+
+
+def commit_msg(info):
+    """
+    Generate a commit message describing the operation
+    we just did
+    """
+    k = info.key
+    mini_new_doc = narrow_to_span(info.after, info.span)
+
+    lines = [("%s_%s: split dialogue before turn %d" %
+              (k.doc, k.subdoc, info.tid)),
+             "",
+             annotate_doc(mini_new_doc),
+             "..."]
+    return "\n".join(lines)
+
+
+def main(args):
+    """
+    Subcommand main.
+
+    You shouldn't need to call this yourself if you're using
+    `config_argparser`
+    """
+    corpus = read_corpus(args, verbose=True)
+    tcache = TimestampCache()
+    output_dir = get_output_dir(args, default_overwrite=True)
+
+    for key in corpus:
+        print(key)
+        new_doc = corpus[key]
+        old_doc = copy.deepcopy(new_doc)
+        span = _split_dialogue(tcache, new_doc, args.turn)
+        diffs = _mini_diff(key, args, old_doc, new_doc, span)
+        print("\n".join(diffs).encode('utf-8'), file=sys.stderr)
+        save_document(output_dir, key, new_doc)
+        commit_info = CommitInfo(key=key,
+                                 before=old_doc,
+                                 after=new_doc,
+                                 span=span,
+                                 tid=args.turn)
+    announce_output_dir(output_dir)
+    if commit_info and not args.no_commit_msg:
+        print("-----8<------")
+        print(commit_msg(commit_info))

--- a/educe/stac/edit/cmd/split_edu.py
+++ b/educe/stac/edit/cmd/split_edu.py
@@ -13,19 +13,19 @@ import sys
 import educe.annotation
 import educe.stac
 
-from ..annotate import show_diff, annotate_doc
-from ..glozz import\
+from educe.stac.util.annotate import show_diff, annotate_doc
+from educe.stac.util.glozz import\
     TimestampCache, set_anno_author, set_anno_date,\
     anno_id_from_tuple
-from ..args import\
+from educe.stac.util.args import\
     add_usual_input_args, add_usual_output_args,\
     add_commit_args,\
     read_corpus_with_unannotated,\
     get_output_dir, announce_output_dir,\
     comma_span
-from ..doc import\
+from educe.stac.util.doc import\
     narrow_to_span, enclosing_span, retarget
-from ..output import save_document
+from educe.stac.util.output import save_document
 
 
 NAME = 'split-edu'

--- a/educe/stac/edit/cmd/split_edu.py
+++ b/educe/stac/edit/cmd/split_edu.py
@@ -67,7 +67,7 @@ def _tweak_presplit(tcache, doc, spans):
                    if x.text_span() == span and educe.stac.is_edu(x)]
         if not matches:
             raise Exception("No matches found for %s in %s" %
-                            (span, doc.origin), file=sys.stderr)
+                            (span, doc.origin))
         edu = matches[0]
         old_id = edu.local_id()
         new_id = anno_id_from_tuple((_AUTHOR, tcache.get(span)))

--- a/educe/stac/edit/cmd/split_edu.py
+++ b/educe/stac/edit/cmd/split_edu.py
@@ -119,9 +119,9 @@ def _actually_split(tcache, doc, spans, edu):
                                   frozenset(),
                                   frozenset(),
                                   'Complex_discourse_unit',
-                                  {'author': _AUTHOR,
-                                   'creation-date': str(cdu_stamp)},
-                                  metadata={})
+                                  {},
+                                  metadata={'author': _AUTHOR,
+                                            'creation-date': str(cdu_stamp)})
     cdu.fleshout(new_edus)
 
     want_cdu = retarget(doc, edu.local_id(), cdu)

--- a/educe/stac/edit/cmd/split_edu.py
+++ b/educe/stac/edit/cmd/split_edu.py
@@ -50,7 +50,7 @@ def config_argparser(parser):
                         required=True,
                         nargs='+',
                         help='Desired output spans (must cover original EDU)')
-    add_usual_output_args(parser)
+    add_usual_output_args(parser, default_overwrite=True)
     add_commit_args(parser)
     parser.set_defaults(func=main)
 
@@ -213,7 +213,7 @@ def main(args):
     """
     corpus = read_corpus_with_unannotated(args)
     tcache = TimestampCache()
-    output_dir = get_output_dir(args)
+    output_dir = get_output_dir(args, default_overwrite=True)
     commit_info = None
     for k in corpus:
         old_doc = corpus[k]

--- a/educe/stac/edit/cmd/split_edu.py
+++ b/educe/stac/edit/cmd/split_edu.py
@@ -10,6 +10,7 @@ from collections import namedtuple
 import copy
 import sys
 
+from educe.annotation import Span
 import educe.annotation
 import educe.stac
 
@@ -24,7 +25,7 @@ from educe.stac.util.args import\
     get_output_dir, announce_output_dir,\
     comma_span
 from educe.stac.util.doc import\
-    narrow_to_span, enclosing_span, retarget
+    narrow_to_span, retarget
 from educe.stac.util.output import save_document
 
 
@@ -113,7 +114,7 @@ def _actually_split(tcache, doc, spans, edu):
         edu2.span = span
         doc.units.append(edu2)
 
-    cdu_stamp = tcache.get(enclosing_span(spans))
+    cdu_stamp = tcache.get(Span.merge_all(spans))
     cdu = educe.annotation.Schema(anno_id_from_tuple((_AUTHOR, cdu_stamp)),
                                   frozenset(new_edus),
                                   frozenset(),
@@ -135,7 +136,7 @@ def _split_edu(tcache, k, doc, spans):
     Find the edu covered by these spans and do the split
     """
     # seek edu
-    big_span = enclosing_span(spans)
+    big_span = Span.merge_all(spans)
     matches = [x for x in doc.units
                if x.text_span() == big_span and educe.stac.is_edu(x)]
     if not matches and k.stage != 'discourse':
@@ -218,7 +219,7 @@ def main(args):
     for k in corpus:
         old_doc = corpus[k]
         new_doc = copy.deepcopy(old_doc)
-        span = enclosing_span(args.spans)
+        span = Span.merge_all(args.spans)
         _split_edu(tcache, k, new_doc, args.spans)
         diffs = _mini_diff(k, old_doc, new_doc, span)
         print("\n".join(diffs).encode('utf-8'), file=sys.stderr)

--- a/educe/stac/oneoff/cmd/clean_dialogue_acts.py
+++ b/educe/stac/oneoff/cmd/clean_dialogue_acts.py
@@ -30,7 +30,7 @@ def config_argparser(parser):
                         nargs='?',
                         help='corpus dir')
     add_corpus_filters(parser, fields=fields_without(["stage"]))
-    add_usual_output_args(parser)
+    add_usual_output_args(parser, default_overwrite=True)
     parser.set_defaults(func=main)
 
 # not the same as educe.stac.annotation
@@ -47,7 +47,7 @@ def main(args):
 
     corpus = read_corpus(args,
                          preselected={"stage": ["units"]})
-    output_dir = get_output_dir(args)
+    output_dir = get_output_dir(args, default_overwrite=True)
     for k in corpus:
         doc = corpus[k]
         for edu in filter(educe.stac.is_edu, doc.units):

--- a/educe/stac/oneoff/cmd/clean_dialogue_acts.py
+++ b/educe/stac/oneoff/cmd/clean_dialogue_acts.py
@@ -50,7 +50,7 @@ def main(args):
     output_dir = get_output_dir(args, default_overwrite=True)
     for k in corpus:
         doc = corpus[k]
-        for edu in filter(educe.stac.is_edu, doc.units):
+        for edu in [x for x in doc.units if educe.stac.is_edu(x)]:
             etypes = frozenset(educe.stac.split_type(edu))
             etypes2 = frozenset(RENAMES.get(t, t) for t in etypes)
             if etypes != etypes2:

--- a/educe/stac/oneoff/cmd/clean_emoticons.py
+++ b/educe/stac/oneoff/cmd/clean_emoticons.py
@@ -70,7 +70,7 @@ def sorted_turns(doc):
     """
     Turn annotations in a document, sorted by text span
     """
-    return sorted_first_widest(filter(educe.stac.is_turn, doc.units))
+    return sorted_first_widest(x for x in doc.units if educe.stac.is_turn(x))
 
 
 def absorb_emoticon(doc, stamp, penult, last):
@@ -163,7 +163,7 @@ def family_banner(doc, subdoc, keys):
             return k.stage
 
     fam = "%s [%s]" % (doc, subdoc)
-    members = ", ".join(map(show_member, keys))
+    members = ", ".join(show_member(x) for x in keys)
 
     return "========== %s =========== (%s)" % (fam, members)
 

--- a/educe/stac/oneoff/cmd/clean_emoticons.py
+++ b/educe/stac/oneoff/cmd/clean_emoticons.py
@@ -40,7 +40,7 @@ def config_argparser(parser):
                         help='corpus dir')
     # don't allow stage control
     add_corpus_filters(parser, fields=fields_without(["stage"]))
-    add_usual_output_args(parser)
+    add_usual_output_args(parser, default_overwrite=True)
     parser.set_defaults(func=main)
 
 
@@ -178,7 +178,7 @@ def main(args):
     corpus = read_corpus_with_unannotated(args)
     postags = educe.stac.postag.read_tags(corpus, args.corpus)
     tcache = TimestampCache()
-    output_dir = get_output_dir(args)
+    output_dir = get_output_dir(args, default_overwrite=True)
 
     families = collections.defaultdict(list)
     discourse_subcorpus = {}

--- a/educe/stac/oneoff/cmd/clean_schemas.py
+++ b/educe/stac/oneoff/cmd/clean_schemas.py
@@ -30,7 +30,7 @@ def config_argparser(parser):
                         help='corpus dir')
     # don't allow stage control
     add_corpus_filters(parser, fields=fields_without(["stage"]))
-    add_usual_output_args(parser)
+    add_usual_output_args(parser, default_overwrite=True)
     parser.set_defaults(func=main)
 
 
@@ -43,7 +43,7 @@ def main(args):
     """
     corpus = read_corpus(args,
                          preselected={'stage': ['discourse', 'units']})
-    output_dir = get_output_dir(args)
+    output_dir = get_output_dir(args, default_overwrite=True)
     for key in corpus:
         doc = corpus[key]
         to_delete = []

--- a/educe/stac/util/args.py
+++ b/educe/stac/util/args.py
@@ -93,8 +93,8 @@ def get_output_dir(args, default_overwrite=False):
     We try the following in order:
 
     1. If `--output` is given explicitly, we'll just use/create that
-    2. If `default_overwrite` is True, or the the subcommand supports
-       `--overwrite`, and the user specifies it on the command line,
+    2. If `default_overwrite` is True, or the user specifies `--overwrite`
+       on the command line (provided the command supports it),
        the output directory may well be the original corpus dir
        (*gulp*! Better use version control!)
     3. OK just make a temporary directory. Later on, you'll probably want

--- a/educe/stac/util/args.py
+++ b/educe/stac/util/args.py
@@ -7,7 +7,6 @@ Command line options
 
 from __future__ import print_function
 import argparse
-import copy
 import glob
 import os
 import sys

--- a/educe/stac/util/args.py
+++ b/educe/stac/util/args.py
@@ -44,7 +44,7 @@ def check_easy_settings(args):
             sys.exit("I don't know about any document called " + args.doc)
 
     guess_report = "{corpus} --doc \"{doc}\""
-    if args.annotator is None:
+    if 'annotator' in args.__dict__ and args.annotator is None:
         args.annotator = METAL_STR
         guess_report += ' --annotator "{}"'.format(args.annotator)
 

--- a/educe/stac/util/args.py
+++ b/educe/stac/util/args.py
@@ -78,17 +78,17 @@ def read_corpus_with_unannotated(args, verbose=True):
     return reader.slurp(anno_files, verbose=verbose)
 
 
-def get_output_dir(args):
-    """
-    Return the output directory specified on (or inferred from) the command
-    line arguments, *creating it if necessary*.
+def get_output_dir(args, default_overwrite=False):
+    """Return the output dir specified or inferred from command
+    line args.
 
     We try the following in order:
 
     1. If `--output` is given explicitly, we'll just use/create that
-    2. If the subcommand supports `--overwrite`, and the user specifies it
-       on the command line, the output directory may well be the original
-       corpus dir (*gulp*! Better use version control!)
+    2. If `default_overwrite` is True, or the the subcommand supports
+       `--overwrite`, and the user specifies it on the command line,
+       the output directory may well be the original corpus dir
+       (*gulp*! Better use version control!)
     3. OK just make a temporary directory. Later on, you'll probably want
        to call `announce_output_dir`.
     """
@@ -100,7 +100,8 @@ def get_output_dir(args):
         elif not os.path.isdir(args.output):
             os.makedirs(args.output)
         return args.output
-    elif "overwrite_input" in args.__dict__ and args.overwrite_input:
+    elif (default_overwrite or
+          ("overwrite_input" in args.__dict__ and args.overwrite_input)):
         return args.corpus
     else:
         return tempfile.mkdtemp()
@@ -156,14 +157,16 @@ def add_usual_input_args(parser,
         educe.util.add_corpus_filters(parser)
 
 
-def add_usual_output_args(parser):
+def add_usual_output_args(parser, default_overwrite=False):
     """
     Augment a subcommand argparser with typical output arguments,
     Sometimes your subcommand may require slightly different output
     arguments, in which case, just don't call this function.
     """
+    default = '(default {})'.format('overwrite!' if default_overwrite
+                                    else 'mktemp')
     parser.add_argument('--output', '-o', metavar='DIR',
-                        help='output directory (default mktemp)')
+                        help='output directory ' + default)
     parser.add_argument('--overwrite-input', action='store_true',
                         help='save results back to input dir')
 

--- a/educe/stac/util/args.py
+++ b/educe/stac/util/args.py
@@ -44,7 +44,12 @@ def check_easy_settings(args):
             sys.exit("I don't know about any document called " + args.doc)
 
     guess_report = "{corpus} --doc \"{doc}\""
-    if 'annotator' in args.__dict__ and args.annotator is None:
+    want_unanno = ('stage' in args.__dict__ and
+                   args.stage is not None and
+                   'unannotated'.startswith(args.stage))
+    if ('annotator' in args.__dict__ and
+            not want_unanno and
+            args.annotator is None):
         args.annotator = METAL_STR
         guess_report += ' --annotator "{}"'.format(args.annotator)
 

--- a/educe/stac/util/args.py
+++ b/educe/stac/util/args.py
@@ -12,6 +12,7 @@ import os
 import sys
 import tempfile
 
+from educe.stac.corpus import METAL_STR
 import educe.annotation
 import educe.stac
 import educe.util
@@ -43,6 +44,9 @@ def check_easy_settings(args):
             sys.exit("I don't know about any document called " + args.doc)
 
     guess_report = "{corpus} --doc \"{doc}\""
+    if args.annotator is None:
+        args.annotator = METAL_STR
+        guess_report += ' --annotator "{}"'.format(args.annotator)
 
     print("Guessing convenience settings:", file=sys.stderr)
     print(guess_report.format(**args.__dict__), file=sys.stderr)

--- a/educe/stac/util/cmd/__init__.py
+++ b/educe/stac/util/cmd/__init__.py
@@ -7,9 +7,12 @@ stac-util subcommands
 
 # pylint: disable=redefined-builtin
 # (we have a command called filter)
-from . import (count, count_rfc, filter, filter_graph, graph, insert,
-               merge_dialogue, merge_edus, move, nudge, nudge_dialogue, rename,
-               rewrite, split_edu, text, tmp)
+from . import (count,
+               count_rfc,
+               filter,
+               filter_graph,
+               graph,
+               text)
 
 # at the time of this writing argparse doesn't support a way to group
 # subcommands into sections, but maybe we can wait for it to grow such
@@ -20,21 +23,10 @@ SUBCOMMAND_SECTIONS =\
       [text,
        count,
        count_rfc,
-       graph,
-       filter_graph]),
-     ('Editing',
+       graph]),
+     ('Filters',
       [filter,
-       rename,
-       rewrite,
-       merge_dialogue,
-       merge_edus,
-       split_edu,
-       nudge,
-       nudge_dialogue]),
-     ('Advanced editing',
-      [insert,
-       move,
-       tmp])]
+       filter_graph])]
 
 SUBCOMMANDS = []
 for descr, section in SUBCOMMAND_SECTIONS:

--- a/educe/stac/util/doc.py
+++ b/educe/stac/util/doc.py
@@ -226,12 +226,16 @@ def split_doc(doc, middle):
 
     leftovers = [x for x in doc.annotations()
                  if straddles(middle, x.text_span())]
+
     if leftovers:
-        oops = "Can't split document [{0}] at {1}".format(doc.origin, middle) +\
-               " because it is straddled by following annotations:\n" +\
-               "\n".join(map(str, leftovers)) +\
-               "\nEither split at a different place, or remove the annotations"
-        raise StacDocException(oops)
+        oops = ("Can't split document [{origin}] at {middle} because it is "
+                "straddled by the following annotations:\n"
+                "{annotations}\n"
+                "Either split at a different place or remove the annotations")
+        leftovers = [' * %s %s' % (x.text_span(), x) for x in leftovers]
+        raise StacDocException(oops.format(origin=doc.origin,
+                                           middle=middle,
+                                           annotations='\n'.join(leftovers)))
 
     prefix = Span(0, middle)
     suffix = Span(middle, doc_len)

--- a/educe/stac/util/doc.py
+++ b/educe/stac/util/doc.py
@@ -179,18 +179,6 @@ def compute_renames(avoid, incoming):
     return renames
 
 
-def enclosing_span(spans):
-    """
-    Return a span that stretches from one end of a collection of spans
-    to the other end.
-    """
-    if len(spans) < 1:
-        raise ValueError("must have at least one span")
-
-    return Span(min(x.char_start for x in spans),
-                max(x.char_end for x in spans))
-
-
 def narrow_to_span(doc, span):
     """
     Return a deep copy of a document with only the text and

--- a/educe/stac/util/doc.py
+++ b/educe/stac/util/doc.py
@@ -337,7 +337,7 @@ def move_portion(renames, src_doc, tgt_doc,
     middle = rename_ids(renames,
                         shift_annotations(snipped, len(prefix_text)))
 
-    if tgt_split > 0:
+    if tgt_split >= 0:
         new_tgt_doc = shift_annotations(tgt_doc, len(middle_text),
                                         point=tgt_split)
     else:

--- a/etc/redo-api-doc
+++ b/etc/redo-api-doc
@@ -3,6 +3,7 @@
 # meant to be run from educe root
 rm -rf docs/api-doc
 sphinx-apidoc educe --module-first -o docs/api-doc\
+        educe/*/edit/cmd\
         educe/*/util/cmd\
         educe/*/oneoff/cmd\
         educe/*/learning/cmd\

--- a/scripts/stac-edit
+++ b/scripts/stac-edit
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# pylint: disable=invalid-name
+# We have a script here, not a module, so it's ok to have
+# a funny name
+# pylint: enable=invalid-name
+
+# Author: Eric Kow
+# License: CeCILL (French BSD3-like)
+
+"""
+STAC project Swiss-Army knife (editing)
+"""
+
+from argparse import ArgumentParser
+
+from educe.stac.edit.cmd import SUBCOMMANDS
+from educe.stac.util.args import check_easy_settings
+from educe.util import add_subcommand
+
+
+def main():
+    "stac-edit main"
+
+    psr = ArgumentParser(description='STAC batch editor')
+    subparsers = psr.add_subparsers(help='sub-command help')
+
+    for module in SUBCOMMANDS:
+        subparser = add_subcommand(subparsers, module)
+        module.config_argparser(subparser)
+
+    psr.add_argument('--verbose', '-v',
+                     action='count',
+                     default=0)
+    args = psr.parse_args()
+    check_easy_settings(args)
+    args.func(args)
+
+main()


### PR DESCRIPTION
A raft of changes I made while doing another round of annotations cleanup, mainly to 

* make the UI a bit friendlier (target audience: Eric, though): stac-util now split into util (for looking at things) and edit (for modifying the corpus)
* stac-edit now overwrites by default (I've gotten used enough to these tools to trust them a bit more)
* some new utilities to help with new requests: delete-anno (for those redundant rels), split-dialogue (for a complicated move in s1-league1-game3, see svn), and fancier stac-edit move
