### PR TITLE
[MRG + 1] tune easy mode dir recognition

### DIFF
--- a/educe/stac/util/args.py
+++ b/educe/stac/util/args.py
@@ -21,6 +21,7 @@ STAC_GLOBS = frozenset([
     "data/pilot",
     "data/socl-season1",
     "data/socl-season2",
+    "data/TEST",
 ])
 
 

--- a/educe/stac/util/args.py
+++ b/educe/stac/util/args.py
@@ -17,9 +17,11 @@ import educe.annotation
 import educe.stac
 import educe.util
 
-STAC_GLOBS = {"data/pilot": "pilot*",
-              "data/socl-season1": "s1-league*-game*",
-              "data/socl-season2": "s2-*"}
+STAC_GLOBS = frozenset([
+    "data/pilot",
+    "data/socl-season1",
+    "data/socl-season2",
+])
 
 
 def check_easy_settings(args):


### PR DESCRIPTION
Stac utilities have an "easy mode" where if you specify a --doc without specifying a corpus dir, it will try to infer the likely intended settings to go with it (particularly the corpus directory).  But this was not yeth available for data/TEST