### PR TITLE
[MRG] RST relation with nuclearity

### DIFF
--- a/educe/rst_dt/annotation.py
+++ b/educe/rst_dt/annotation.py
@@ -330,6 +330,45 @@ class SimpleRSTTree(SearchableTree, Standoff):
             return SimpleRSTTree(node, kids, tree.origin)
 
     @classmethod
+    def incorporate_nuclearity_into_label(cls, tree):
+        """Integrate nuclearity of the children into each node's label.
+
+        Nuclearity of the children is incorporated in one of two forms,
+        NN for multi- and NS for mono-nuclear relations.
+
+        Parameters
+        ----------
+        tree: SimpleRSTTree
+            The tree of which we want a version with nuclearity incorporated
+
+        Returns
+        -------
+        mod_tree: SimpleRSTTree
+            The same tree but with the type of nuclearity incorporated
+
+        Note
+        ----
+        This is probably not the best way to provide this functionality.
+        In other words, refactoring is much needed here.
+        """
+        if len(tree) == 1:
+            node = copy.copy(treenode(tree))
+            return SimpleRSTTree(node, tree, tree.origin)
+        else:
+            node = copy.copy(treenode(tree))
+            # convenient string representation of what the children look like
+            # here one of NS, SN, NN
+            nscode = "".join(treenode(kid).nuclearity[0] for kid in tree)
+            assert nscode in frozenset(['NS', 'SN', 'NN'])
+            rel_sfx = 'NS' if nscode in ['NS', 'SN'] else 'NN'
+            # or rel_sfx = nscode if... to get the same 41 relations as Joty
+            node.rel = node.rel + '-' + rel_sfx
+            # recurse
+            kids = [cls.incorporate_nuclearity_into_label(kid)
+                    for kid in tree]
+            return SimpleRSTTree(node, kids, tree.origin)
+
+    @classmethod
     def to_binary_rst_tree(cls, tree, rel=None):
         """
         Build and return a binary `RSTTree` from a `SimpleRSTTree`.

--- a/educe/rst_dt/corpus.py
+++ b/educe/rst_dt/corpus.py
@@ -147,7 +147,8 @@ class RstDtParser(object):
         # convert to binary tree
         rsttree = SimpleRSTTree.from_rst_tree(orig_rsttree)
         # NEW incorporate nuclearity into label
-        if True:
+        # TODO add a parameter (in init or this function) to trigger this
+        if False:
             rsttree = SimpleRSTTree.incorporate_nuclearity_into_label(rsttree)
         doc.rsttree = rsttree
 

--- a/educe/rst_dt/corpus.py
+++ b/educe/rst_dt/corpus.py
@@ -124,23 +124,24 @@ class RstDtParser(object):
     def decode(self, doc_key):
         """Decode a document from the RST-DT (gold)"""
         # create a DocumentPlus
-        # the RST tree is currently pivotal to get all the layers of info
-        orig_rsttree = self.corpus[doc_key]
-        # convert relation labels if needed
-        if self.rel_conv is not None:
-            orig_rsttree = self.rel_conv(orig_rsttree)
-        # the RST tree is backed by an RSTContext that contains the document
-        # text and structure (paragraphs and badly segmented sents)
-        rst_context = treenode(orig_rsttree).context
         # grouping is the document name
         grouping = os.path.basename(id_to_path(doc_key))
+        # the RST tree is currently pivotal to get all the layers of info,
+        # including the RSTContext that contains the document text and
+        # structure (paragraphs + poorly segmented sentences)
+        orig_rsttree = self.corpus[doc_key]
+        rst_context = treenode(orig_rsttree).context
         # finally...
         doc = DocumentPlus(doc_key, grouping, rst_context)
 
-        # TODO get EDUs here
+        # TODO get EDUs here rather than below (see dep tree)
         # edus = orig_rsttree.leaves()
         # doc.edus.extend(edus)
+
         # attach original RST tree
+        # convert relation labels if needed
+        if self.rel_conv is not None:
+            orig_rsttree = self.rel_conv(orig_rsttree)
         doc.orig_rsttree = orig_rsttree
 
         # convert to binary tree

--- a/educe/rst_dt/corpus.py
+++ b/educe/rst_dt/corpus.py
@@ -145,6 +145,9 @@ class RstDtParser(object):
 
         # convert to binary tree
         rsttree = SimpleRSTTree.from_rst_tree(orig_rsttree)
+        # NEW incorporate nuclearity into label
+        if True:
+            rsttree = SimpleRSTTree.incorporate_nuclearity_into_label(rsttree)
         doc.rsttree = rsttree
 
         # convert to dep tree

--- a/educe/rst_dt/document_plus.py
+++ b/educe/rst_dt/document_plus.py
@@ -41,10 +41,15 @@ class DocumentPlus(object):
 
     def __init__(self, key, grouping, rst_context):
         """
-        key is an educe.corpus.FileId
-        grouping designates the corresponding file in the corpus
-        rst_context is an RSTContext that encapsulates the text and raw
-            document structure
+        Parameters
+        ----------
+        key: educe.corpus.FileId
+            Unique identifier for this document
+        grouping: string
+            Path to the corresponding file in the corpus
+        rst_context: RSTContext
+            Encapsulating object for the text and raw document structure
+            (sentences and paragraphs)
         """
         # document identification
         self.key = key
@@ -308,8 +313,8 @@ class DocumentPlus(object):
 
         # regular EDUs
         for edu in edus[1:]:
-            tree_idcs = [tree_idx
-                         for tree_idx, tree in enumerate(syn_trees[1:], start=1)
+            tree_idcs = [t_idx
+                         for t_idx, tree in enumerate(syn_trees[1:], start=1)
                          if tree is not None and tree.overlaps(edu)]
 
             if len(tree_idcs) == 1:
@@ -330,6 +335,7 @@ class DocumentPlus(object):
                     emsg = ('Segmentation mismatch:',
                             'one EDU, more than one PTB tree')
                     print(edu)
+                    ptrees = [syn_trees[t_idx] for t_idx in tree_idcs]
                     for ptree in ptrees:
                         print('    ', [str(leaf) for leaf in ptree.leaves()])
                     raise ValueError(emsg)


### PR DESCRIPTION
This PR adds functions to concatenate relation label with nuclearity, e.g. `elaboration-NN`.
Two suffixes are distinguished: NN and NS, where the position of the satellite in the latter is indicated by the orientation of the edge.

This integration of relation and nuclearity is currently inactivated but should become optional in a future version.