### PR TITLE
FIX ill-sorted CoreNLP tokens for RST because of string global ids

### DIFF
--- a/educe/rst_dt/corenlp.py
+++ b/educe/rst_dt/corenlp.py
@@ -89,7 +89,10 @@ def read_corenlp_result(doc, corenlp_doc):
     for sent in sentences:
         sid = sent['id']
         tokens_dict = educe_tokens[sid]
-        sorted_tokens = [tokens_dict[x] for x in sorted(tokens_dict)]
+        # NEW extract local id to properly sort tokens
+        tok_local_id = lambda x: int(x[len(sid) + 1:])
+        sorted_tokens = [tokens_dict[x]
+                         for x in sorted(tokens_dict, key=tok_local_id)]
         # ctree
         tree = nltk.tree.Tree.fromstring(sent['parse'])
         educe_ctree = ConstituencyTree.build(tree, sorted_tokens)

--- a/educe/stac/corenlp.py
+++ b/educe/stac/corenlp.py
@@ -231,7 +231,12 @@ def read_corenlp_result(doc, corenlp_doc, tid=None):
     for turn, sent in zip(turns, sentences):
         sid = sent['id']
         tokens_dict = educe_tokens[sid]
+        # FIXME tokens are probably not properly ordered because token ids
+        # are global ids, i.e. strings like "1-18" (sentence 1, token 18)
+        # which means basic sorting ranks "1-10" before "1-2"
+        # cf. educe.rst_dt.corenlp
         sorted_tokens = [tokens_dict[x] for x in sorted(tokens_dict.keys())]
+        # end FIXME
         tree = nltk.tree.Tree.fromstring(sent['parse'])
         educe_tree = ConstituencyTree.build(tree, sorted_tokens)
 


### PR DESCRIPTION
The same error probably affects `educe.stac.corenlp`.
Checking whether the error occurs and fixing the bug in the latter is left for future work.