### PR TITLE
[MRG + 1] ENH rank, nuclearity as first-class, better support for CODRA output

### DIFF
--- a/educe/rst_dt/codra.py
+++ b/educe/rst_dt/codra.py
@@ -1,0 +1,64 @@
+"""This module provides support for the CODRA discourse parser.
+"""
+
+import codecs
+import glob
+import os
+
+from .parse import parse_rst_dt_tree
+
+
+def load_codra_output_files(container_path, level='doc'):
+    """Load ctrees output by CODRA on the TEST section of RST-WSJ.
+
+    Parameters
+    ----------
+    container_path: string
+        Path to the main folder containing CODRA's output
+
+    level: {'doc', 'sent'}, optional (default='doc')
+        Level of decoding: document-level or sentence-level
+
+    Returns
+    -------
+    data: dict
+        Dictionary that should be akin to a sklearn Bunch, with
+        interesting keys 'filenames', 'doc_names' and 'rst_ctrees'.
+
+    Notes
+    -----
+    To ensure compatibility with the rest of the code base, doc_names
+    are automatically added the ".out" extension. This would not work
+    for fileX documents, but they are absent from the TEST section of
+    the RST-WSJ treebank.
+    """
+    if level == 'doc':
+        file_ext = '.doc_dis'
+    elif level == 'sent':
+        file_ext = '.sen_dis'
+    else:
+        raise ValueError("level {} not in ['doc', 'sent']".format(level))
+
+    # find all files with the right extension
+    pathname = os.path.join(container_path, '*{}'.format(file_ext))
+    # filenames are sorted by name to avoid having to realign data
+    # loaded with different functions
+    filenames = sorted(glob.glob(pathname))  # glob.glob() returns a list
+
+    # find corresponding doc names
+    doc_names = [os.path.splitext(os.path.basename(filename))[0] + '.out'
+                 for filename in filenames]
+
+    # load the RST trees
+    rst_ctrees = []
+    for filename in filenames:
+        with codecs.open(filename, 'r', 'utf-8') as f:
+            # TODO (?) add support for and use RSTContext
+            rst_ctree = parse_rst_dt_tree(f.read(), None)
+            rst_ctrees.append(rst_ctree)
+
+    data = dict(filenames=filenames,
+                doc_names=doc_names,
+                rst_ctrees=rst_ctrees)
+
+    return data

--- a/educe/rst_dt/corpus.py
+++ b/educe/rst_dt/corpus.py
@@ -23,11 +23,12 @@ from .annotation import SimpleRSTTree
 from .deptree import RstDepTree
 
 
+RELMAP_112_18_FILE = join(dirname(__file__), 'rst_112to18.txt')
+
+
 # ---------------------------------------------------------------------
 # Corpus
 # ---------------------------------------------------------------------
-
-
 class Reader(educe.corpus.Reader):
     """
     See `educe.corpus.Reader` for details
@@ -126,7 +127,7 @@ class RstDtParser(object):
         # setup label converter for the desired granularity
         # 'fine' means we don't change anything
         if coarse_rels:
-            relmap_file = join(dirname(__file__), 'rst_112to18.txt')
+            relmap_file = RELMAP_112_18_FILE
             self.rel_conv = RstRelationConverter(relmap_file).convert_tree
         else:
             self.rel_conv = None

--- a/educe/rst_dt/corpus_diagnostics.py
+++ b/educe/rst_dt/corpus_diagnostics.py
@@ -12,21 +12,19 @@ import pandas as pd
 from educe.internalutil import treenode
 from educe.rst_dt.annotation import RSTTree
 from educe.rst_dt.corpus import (Reader as RstReader,
-                                 RstRelationConverter)
+                                 RstRelationConverter,
+                                 RELMAP_112_18_FILE)
 
 
 # RST corpus
 # TODO import CORPUS_DIR/CD_TRAIN e.g. from educe.rst_dt.rst_wsj_corpus
-CORPUS_DIR = os.path.join('/home/mathieu/travail/recherche/melodi/educe',
+CORPUS_DIR = os.path.join(os.path.dirname(__file__),
+                          '..', '..',
                           'data/rst_discourse_treebank/data',
                           'RSTtrees-WSJ-main-1.0/')
 CD_TRAIN = os.path.join(CORPUS_DIR, 'TRAINING')
 # relation converter (fine- to coarse-grained labels)
-# TODO same as above
-RELMAP_FILE = os.path.join('/home/mathieu/travail/recherche/melodi/educe',
-                           'educe', 'rst_dt',
-                           'rst_112to18.txt')
-REL_CONV = RstRelationConverter(RELMAP_FILE).convert_tree
+REL_CONV = RstRelationConverter(RELMAP_112_18_FILE).convert_tree
 
 
 def load_training_as_dataframe():
@@ -91,6 +89,14 @@ def load_training_as_dataframe():
 
 def get_most_frequent_unuc(df, verbose=False):
     """Get the most frequent undirected nuclearity for each relation.
+
+    Parameters
+    ----------
+    df: pandas.DataFrame
+        Relations present in the corpus
+
+    verbose: boolean, default: False
+        Trigger textual traces
 
     Returns
     -------

--- a/educe/rst_dt/corpus_diagnostics.py
+++ b/educe/rst_dt/corpus_diagnostics.py
@@ -1,0 +1,152 @@
+"""This module is a loose collection of diagnostic functions on an RST corpus.
+
+"""
+
+from __future__ import print_function
+
+from collections import Counter
+import os
+
+import pandas as pd
+
+from educe.internalutil import treenode
+from educe.rst_dt.annotation import RSTTree
+from educe.rst_dt.corpus import (Reader as RstReader,
+                                 RstRelationConverter)
+
+
+# RST corpus
+# TODO import CORPUS_DIR/CD_TRAIN e.g. from educe.rst_dt.rst_wsj_corpus
+CORPUS_DIR = os.path.join('/home/mathieu/travail/recherche/melodi/educe',
+                          'data/rst_discourse_treebank/data',
+                          'RSTtrees-WSJ-main-1.0/')
+CD_TRAIN = os.path.join(CORPUS_DIR, 'TRAINING')
+# relation converter (fine- to coarse-grained labels)
+# TODO same as above
+RELMAP_FILE = os.path.join('/home/mathieu/travail/recherche/melodi/educe',
+                           'educe', 'rst_dt',
+                           'rst_112to18.txt')
+REL_CONV = RstRelationConverter(RELMAP_FILE).convert_tree
+
+
+def load_training_as_dataframe():
+    """Load training section of the RST-WSJ corpus as a pandas.DataFrame.
+
+    Returns
+    -------
+    df: pandas.DataFrame
+        DataFrame of all instances of relations in the training section.
+        Interesting columns are 'rel', 'nuc_sig', 'arity'
+    """
+    rst_phrases = []  # list of rows, each represented as a dict
+
+    rst_reader = RstReader(CD_TRAIN)
+    rst_corpus = rst_reader.slurp()
+    for doc_id, rtree_ref in sorted(rst_corpus.items()):
+        # convert labels to coarse
+        coarse_rtree_ref = REL_CONV(rtree_ref)
+        # store "same-unit" subtrees
+        heterogeneous_nodes = []
+        internal_nodes = lambda t: isinstance(t, RSTTree) and len(t) > 1
+        for su_subtree in coarse_rtree_ref.subtrees(filter=internal_nodes):
+            # get each kid's relation
+            kid_rels = tuple(treenode(kid).rel for kid in su_subtree)
+            # filter out nodes whose kids have different relations
+            rels = [r for r in set(kid_rels) if r != 'span']
+            if len(rels) > 1:
+                heterogeneous_nodes.append(kid_rels)
+                continue
+
+            # process homogeneous nodes
+            res = dict()
+            rel = rels[0]
+            res['rel'] = rel
+            # arity
+            res['arity'] = len(su_subtree)  # number of kids
+            # nuclearity signature
+            kid_nucs = tuple(treenode(kid).nuclearity for kid in su_subtree)
+            nuc_sig = ''.join('S' if kid_nuc == 'Satellite' else 'N'
+                              for kid_nuc in kid_nucs)
+            res['nuc_sig'] = (nuc_sig if nuc_sig in frozenset(['SN', 'NS'])
+                              else 'NN')
+            # TODO len(kid_rels) - 1 is the nb of bin rels
+
+            # height
+            rel_hgt = su_subtree.height()
+            res['height'] = rel_hgt
+
+            # TODO disc relations of the grandchildren
+            #
+
+            rst_phrases.append(res)
+    # turn into a DataFrame
+    df = pd.DataFrame(rst_phrases)
+    # add calculated columns
+    # * "undirected" nuclearity, e.g. NS == SN
+    df['unuc_sig'] = map(lambda nuc_sig: ('NS' if nuc_sig in ['NS', 'SN']
+                                          else 'NN'),
+                         df.nuc_sig)
+    return df
+
+
+def get_most_frequent_unuc(df, verbose=False):
+    """Get the most frequent undirected nuclearity for each relation.
+
+    Returns
+    -------
+    most_freq_unuc: dict(str, str)
+        Map each relation to its most frequent (aka mode) undirected
+        nuclearity signature.
+    """
+    # get number of occurrences of each relation
+    # * "directed" nuclearity, e.g. NS != SN
+    # TODO check and try pandas' hierarchical indexing ;
+    # my understanding is we would get relation as 1st and nuclearity as 2nd
+    # levels
+    if verbose:
+        grouped_rel_nuc = df.groupby(['rel', 'nuc_sig'])
+        print('\n'.join('{}: {}'.format(rel_nuc, len(occs))
+                        for rel_nuc, occs in grouped_rel_nuc))
+    # * "undirected" nuclearity, e.g. NS == SN
+    # TODO hierarchical indexing (again)
+    if verbose:
+        grouped_rel_unuc = df.groupby(['rel', 'unuc_sig'])
+        print('\n'.join(
+            '{:{}s}\t{}\t{}'.format(
+                rel, max(len(r) for r in df.rel.unique()), unuc, len(occs))
+            for (rel, unuc), occs in grouped_rel_unuc))
+
+    # use this data to get:
+    # * unambiguously mono-nuclear relations
+    # * unambiguously multi-nuclear relations
+    # * most common nuclearity for the remaining (ambiguous wrt nuclearity)
+    # relations
+    most_freq_unuc = {rel: occs['unuc_sig'].mode()[0]
+                      for rel, occs in df.groupby('rel')}
+    if verbose:
+        print('\n'.join('{}\t{}'.format(rel, unuc)
+                        for rel, unuc in sorted(most_freq_unuc.items())))
+
+    return most_freq_unuc
+
+
+def check_label_ranks():
+    """Examine label and rank of attachment"""
+    # FIXME rewrite entirely
+    labels_ranks_gold = []  # TODO
+    labels_ranks_no_nuc = [(lbl[:-3] if lbl is not None and lbl != 'ROOT'
+                            else lbl, rnk)
+                           for lbl, rnk in labels_ranks_gold]
+    print('\n'.join('{}\t{}\t{}'.format(lbl, rnk, occ)
+                    for (lbl, rnk), occ
+                    in sorted(Counter(labels_ranks_no_nuc).items())))
+    print(sorted(set(lbl for lbl, rnk in labels_ranks_gold)))
+    print('labels inc. nuc: {}'.format(
+        len(set(lbl for lbl, rnk in labels_ranks_gold))))
+    print(('labels inc. rank: {}'.format(
+        len(Counter(labels_ranks_no_nuc)))))
+    print('\n'.join('{}\t{}\t{}'.format(lbl, rnk, occ)
+                    for (lbl, rnk), occ
+                    in sorted(Counter(labels_ranks_gold).items())))
+    print('labels inc. nuc and rank :', len(Counter(labels_ranks_gold)))
+    print('\n\n\n')

--- a/educe/rst_dt/dep2con.py
+++ b/educe/rst_dt/dep2con.py
@@ -300,13 +300,6 @@ def deptree_to_simple_rst_tree(dtree, multinuclear, strategy='id'):
 
     attach_ranker = InsideOutAttachmentRanker(strategy)
 
-    def tgt_nuclearity(rel):
-        """
-        The target of a dep tree link is normally the satellite
-        unless the relation is marked multinuclear
-        """
-        return NUC_N if rel in multinuclear else NUC_S
-
     def mk_leaf(edu):
         """
         Trivial partial tree for use when processing dependency
@@ -335,7 +328,9 @@ def deptree_to_simple_rst_tree(dtree, multinuclear, strategy='id'):
         Return a partial tree, assigning order and nuclearity to
         child trees
         """
-        tgt_nuc = tgt_nuclearity(rel)
+        # the target of a dep tree link is normally the satellite
+        # unless the relation is marked multinuclear
+        tgt_nuc = NUC_N if rel in multinuclear else NUC_S
 
         if src.span.overlaps(tgt.span):
             raise RstDtException("Span %s overlaps with %s " %

--- a/educe/rst_dt/dep2con.py
+++ b/educe/rst_dt/dep2con.py
@@ -12,8 +12,74 @@ from collections import namedtuple
 import itertools
 
 from .annotation import SimpleRSTTree, Node
+from .corpus_diagnostics import (get_most_frequent_unuc,
+                                 load_training_as_dataframe)
 from .deptree import RstDtException, NUC_N, NUC_S, NUC_R
 from ..internalutil import treenode
+
+
+class DummyNuclearityClassifier(object):
+    """Predict the nuclearity of each EDU using simple rules.
+
+    Parameters
+    ----------
+    strategy: str
+        Strategy to use to generate predictions.
+
+        * "unamb_else_most_frequent": predicts multinuclear when the
+        relation label is unambiguously multinuclear in the training
+        set, mononuclear otherwise.
+        * "most_frequent_by_rel": predicts the most frequent nuclearity
+        for the given relation label in the training set.
+
+    TODO
+    ----
+    complete after `sklearn.dummy.DummyClassifier`
+    """
+
+    def __init__(self, strategy="unamb_else_most_frequent"):
+        self.strategy = strategy
+
+    def fit(self, X, y):
+        """Fit the dummy classifier.
+
+        FIXME: currently a no-op.
+
+        Parameters
+        ----------
+        X: list of RstDepTrees
+
+        y: array-like, shape = [n_samples]
+            Target nuclearity array for each EDU of each RstDepTree.
+        """
+        if self.strategy not in ["unamb_else_most_frequent",
+                                  "most_frequent_by_rel"]:
+            raise ValueError("Unknown strategy type.")
+        
+        if self.strategy == "unamb_else_most_frequent":
+            # FIXME automatically get these from the training set
+            self.multinuc_lbls = ['joint', 'same-unit', 'textual']
+
+        elif self.strategy == "most_frequent_by_rel":
+            self.multinuc_lbls = [rel_name for rel_name, mode_unuc
+                                  in get_most_frequent_unuc(
+                                      load_training_as_dataframe()
+                                  ).items()
+                                  if mode_unuc == 'NN']
+
+        # FIXME properly implement fit for the different strategies
+        return self
+
+    def predict(self, X):
+        """Perform classification on test RstDepTrees X.
+        """
+        y = []
+        for dtree in X:
+            yi = [(NUC_N if rel in self.multinuc_lbls else NUC_S)
+                  for rel in dtree.labels]
+            y.append(yi)
+
+        return y
 
 
 class InsideOutAttachmentRanker(object):
@@ -70,7 +136,7 @@ class InsideOutAttachmentRanker(object):
                             'closest-intra-lr-inter-lr',
                             'closest-intra-rl-inter-rl',
                             'closest-intra-rl-inter-lr']:
-            raise ValueError('Unknown transformation strategy '
+             raise ValueError('Unknown transformation strategy '
                              '{stg}'.format(stg=strategy))
         self.strategy = strategy
 
@@ -87,13 +153,13 @@ class InsideOutAttachmentRanker(object):
 
         Parameters
         ----------
-        X: list of triples (RstDepTree, EDU, list of EDUs)
-            Dependency tree, head EDU and its list of modifiers
+        X: list of RstDepTrees
+            Dependency trees for which we want attachment rankings
 
         Returns
         -------
-        sorted_mods: list of EDUs
-            Sorted list of modifiers
+        dt_ranks: list of arrays of ranks
+            Attachment ranking, one per RstDepTree
 
         Notes
         -----
@@ -104,119 +170,131 @@ class InsideOutAttachmentRanker(object):
         """
         strategy = self.strategy
 
-        sorted_mods = []
-        for (dtree, head, targets) in X:
-            sorted_nodes = sorted([head] + targets,
-                                  key=lambda x: dtree.edus[x].span.char_start)
-            centre = sorted_nodes.index(head)
-            # elements to the left and right of the node respectively
-            # these are stacks (outside ... inside)
-            left = sorted_nodes[:centre]
-            right = list(reversed(sorted_nodes[centre+1:]))
+        dt_ranks = []
+        for dtree in X:
+            # for each RstDepTree, the result will be an array of ranks
+            ranks = [0 for hd in dtree.heads]  # initialize result
 
-            # special strategy: 'id' (we know the true targets)
-            if strategy == 'id':
-                result = [left.pop() if (tree in left) else right.pop()
-                          for tree in targets]
+            unique_heads = set(dtree.heads[1:])  # exclude head of fake root
+            for head in unique_heads:
+                targets = [i for i, hd in enumerate(dtree.heads)
+                           if hd == head]
+                # what follows should be well-tested code
+                sorted_nodes = sorted([head] + targets,
+                                      key=lambda x: dtree.edus[x].span.char_start)
+                centre = sorted_nodes.index(head)
+                # elements to the left and right of the node respectively
+                # these are stacks (outside ... inside)
+                left = sorted_nodes[:centre]
+                right = list(reversed(sorted_nodes[centre+1:]))
 
-            # strategies that try to guess the order of attachment
-            else:
-                if strategy == 'lllrrr':
-                    result = [left.pop() if left else right.pop()
-                              for _ in targets]
+                # special strategy: 'id' (we know the true targets)
+                if strategy == 'id':
+                    result = [left.pop() if (tree in left) else right.pop()
+                              for tree in targets]
 
-                elif strategy == 'rrrlll':
-                    result = [right.pop() if right else left.pop()
-                              for _ in targets]
-
-                elif strategy == 'lrlrlr':
-                    # reverse lists of left and right modifiers
-                    # these are queues (inside ... outside)
-                    left_io = list(reversed(left))
-                    right_io = list(reversed(right))
-                    lrlrlr_gen = itertools.chain.from_iterable(
-                        itertools.izip_longest(left_io, right_io))
-                    result = [x for x in lrlrlr_gen
-                              if x is not None]
-
-                elif strategy == 'rlrlrl':
-                    # reverse lists of left and right modifiers
-                    # these are queues (inside ... outside)
-                    left_io = list(reversed(left))
-                    right_io = list(reversed(right))
-                    rlrlrl_gen = itertools.chain.from_iterable(
-                        itertools.izip_longest(right_io, left_io))
-                    result = [x for x in rlrlrl_gen
-                              if x is not None]
-
-                elif strategy == 'closest-rl':
-                    # take closest dependents first, take right over left to
-                    # break ties
-                    head_idx = dtree.idx[head]
-                    sort_key = lambda e: (abs(dtree.idx[e] - head_idx),
-                                          1 if dtree.idx[e] > head_idx else 2)
-                    result = sorted(targets, key=sort_key)
-
-                elif strategy == 'closest-lr':
-                    # take closest dependents first, take left over right to
-                    # break ties
-                    head_idx = dtree.idx[head]
-                    sort_key = lambda e: (abs(dtree.idx[e] - head_idx),
-                                          2 if dtree.idx[e] > head_idx else 1)
-                    result = sorted(targets, key=sort_key)
-
-                # strategies that depend on intra/inter-sentential info
-                # NB: the way sentential info is stored is expected to change
-                # at some point
+                # strategies that try to guess the order of attachment
                 else:
-                    if not hasattr(dtree, 'sent_idx'):
-                        raise ValueError(('Strategy {stg} depends on '
-                                          'sentential information which is '
-                                          'missing here'
-                                          '').format(stg=strategy))
+                    if strategy == 'lllrrr':
+                        result = [left.pop() if left else right.pop()
+                                  for _ in targets]
 
-                    if strategy == 'closest-intra-rl-inter-lr':  # current best
+                    elif strategy == 'rrrlll':
+                        result = [right.pop() if right else left.pop()
+                                  for _ in targets]
+
+                    elif strategy == 'lrlrlr':
+                        # reverse lists of left and right modifiers
+                        # these are queues (inside ... outside)
+                        left_io = list(reversed(left))
+                        right_io = list(reversed(right))
+                        lrlrlr_gen = itertools.chain.from_iterable(
+                            itertools.izip_longest(left_io, right_io))
+                        result = [x for x in lrlrlr_gen
+                                  if x is not None]
+
+                    elif strategy == 'rlrlrl':
+                        # reverse lists of left and right modifiers
+                        # these are queues (inside ... outside)
+                        left_io = list(reversed(left))
+                        right_io = list(reversed(right))
+                        rlrlrl_gen = itertools.chain.from_iterable(
+                            itertools.izip_longest(right_io, left_io))
+                        result = [x for x in rlrlrl_gen
+                                  if x is not None]
+
+                    elif strategy == 'closest-rl':
                         # take closest dependents first, take right over left to
                         # break ties
                         head_idx = dtree.idx[head]
-                        sort_key = lambda e: (1 if dtree.sent_idx[dtree.idx[e]] == dtree.sent_idx[dtree.idx[head]] else 2,
-                                              abs(dtree.idx[e] - head_idx),
-                                              1 if ((dtree.idx[e] > head_idx and
-                                                     dtree.sent_idx[dtree.idx[e]] == dtree.sent_idx[dtree.idx[head]]) or
-                                                    (dtree.idx[e] < head_idx and
-                                                     dtree.sent_idx[dtree.idx[e]] != dtree.sent_idx[dtree.idx[head]])) else 2)
-                        result = sorted(targets, key=sort_key)
-
-                    elif strategy == 'closest-intra-rl-inter-rl':
-                        # take closest dependents first, take right over left to
-                        # break ties
-                        head_idx = dtree.idx[head]
-                        sort_key = lambda e: (1 if dtree.sent_idx[dtree.idx[e]] == dtree.sent_idx[dtree.idx[head]] else 2,
-                                              abs(dtree.idx[e] - head_idx),
+                        sort_key = lambda e: (abs(dtree.idx[e] - head_idx),
                                               1 if dtree.idx[e] > head_idx else 2)
                         result = sorted(targets, key=sort_key)
 
-                    elif strategy == 'closest-intra-lr-inter-lr':
+                    elif strategy == 'closest-lr':
                         # take closest dependents first, take left over right to
                         # break ties
                         head_idx = dtree.idx[head]
-                        sort_key = lambda e: (1 if dtree.sent_idx[dtree.idx[e]] == dtree.sent_idx[dtree.idx[head]] else 2,
-                                              abs(dtree.idx[e] - head_idx),
+                        sort_key = lambda e: (abs(dtree.idx[e] - head_idx),
                                               2 if dtree.idx[e] > head_idx else 1)
                         result = sorted(targets, key=sort_key)
 
+                    # strategies that depend on intra/inter-sentential info
+                    # NB: the way sentential info is stored is expected to change
+                    # at some point
                     else:
-                        raise RstDtException('Unknown transformation strategy'
-                                             ' {stg}'.format(stg=strategy))
+                        if not hasattr(dtree, 'sent_idx'):
+                            raise ValueError(('Strategy {stg} depends on '
+                                              'sentential information which is '
+                                              'missing here'
+                                              '').format(stg=strategy))
 
-            sorted_mods.append(result)
-        return sorted_mods
+                        if strategy == 'closest-intra-rl-inter-lr':  # current best
+                            # take closest dependents first, take right over left to
+                            # break ties
+                            head_idx = dtree.idx[head]
+                            sort_key = lambda e: (1 if dtree.sent_idx[dtree.idx[e]] == dtree.sent_idx[dtree.idx[head]] else 2,
+                                                  abs(dtree.idx[e] - head_idx),
+                                                  1 if ((dtree.idx[e] > head_idx and
+                                                         dtree.sent_idx[dtree.idx[e]] == dtree.sent_idx[dtree.idx[head]]) or
+                                                        (dtree.idx[e] < head_idx and
+                                                         dtree.sent_idx[dtree.idx[e]] != dtree.sent_idx[dtree.idx[head]])) else 2)
+                            result = sorted(targets, key=sort_key)
+
+                        elif strategy == 'closest-intra-rl-inter-rl':
+                            # take closest dependents first, take right over left to
+                            # break ties
+                            head_idx = dtree.idx[head]
+                            sort_key = lambda e: (1 if dtree.sent_idx[dtree.idx[e]] == dtree.sent_idx[dtree.idx[head]] else 2,
+                                                  abs(dtree.idx[e] - head_idx),
+                                                  1 if dtree.idx[e] > head_idx else 2)
+                            result = sorted(targets, key=sort_key)
+
+                        elif strategy == 'closest-intra-lr-inter-lr':
+                            # take closest dependents first, take left over right to
+                            # break ties
+                            head_idx = dtree.idx[head]
+                            sort_key = lambda e: (1 if dtree.sent_idx[dtree.idx[e]] == dtree.sent_idx[dtree.idx[head]] else 2,
+                                                  abs(dtree.idx[e] - head_idx),
+                                                  2 if dtree.idx[e] > head_idx else 1)
+                            result = sorted(targets, key=sort_key)
+
+                        else:
+                            raise RstDtException('Unknown transformation strategy'
+                                                 ' {stg}'.format(stg=strategy))
+
+                # update array of ranks for this deptree
+                for i, tgt in enumerate(result):
+                    ranks[tgt] = i
+
+            dt_ranks.append(ranks)
+        return dt_ranks
 
 
-def deptree_to_simple_rst_tree(dtree, multinuclear, strategy='id'):
+def deptree_to_simple_rst_tree(dtree):
     r"""
-    Given a dependency tree and a collection of relation labels,
-    to be interpreted as being multinuclear, return a 'SimpleRSTTree'.
+    Given a dependency tree with attachment ranking and nuclearity,
+    return a 'SimpleRSTTree'.
     Note that nodes are ordered by text span, so that `e1 -R-> e2` and
     `e2 -R-> e1` would both be interpreted as `R(e1, e2)`, the
     potential difference being which is treated as the nucleus and as
@@ -298,8 +376,6 @@ def deptree_to_simple_rst_tree(dtree, multinuclear, strategy='id'):
     (and so on, until all we have left is a single RST tree).
     """
 
-    attach_ranker = InsideOutAttachmentRanker(strategy)
-
     def mk_leaf(edu):
         """
         Trivial partial tree for use when processing dependency
@@ -323,14 +399,12 @@ def deptree_to_simple_rst_tree(dtree, multinuclear, strategy='id'):
         kids = parts.kids or [parts.edu]
         return SimpleRSTTree(node, kids)
 
-    def connect_trees(src, tgt, rel):
+    def connect_trees(src, tgt, rel, nuc):
         """
         Return a partial tree, assigning order and nuclearity to
         child trees
         """
-        # the target of a dep tree link is normally the satellite
-        # unless the relation is marked multinuclear
-        tgt_nuc = NUC_N if rel in multinuclear else NUC_S
+        tgt_nuc = nuc
 
         if src.span.overlaps(tgt.span):
             raise RstDtException("Span %s overlaps with %s " %
@@ -354,7 +428,7 @@ def deptree_to_simple_rst_tree(dtree, multinuclear, strategy='id'):
                         kids=[left, right])
         return res
 
-    def walk(ancestor, subtree, strategy):
+    def walk(ancestor, subtree):
         """
         The basic descent/ascent driver of our conversion algorithm.
         Note that we are looking at three layers of the dependency
@@ -379,23 +453,36 @@ def deptree_to_simple_rst_tree(dtree, multinuclear, strategy='id'):
         full RST tree for src (through the folding process
         described in the docstring for the main function)
         before connecting it to its ancestor.
+
+        Parameters
+        ----------
+        ancestor: TreeParts
+            TreeParts of the ancestor
+
+        subtree: int
+            Index of the head of the subtree
+
+        Returns
+        -------
+        res: TreeParts
         """
         rel = dtree.labels[subtree]
+        nuc = dtree.nucs[subtree]
+        
         src = mk_leaf(dtree.edus[subtree])
         # descend into each child, but note that we are folding
         # rather than mapping, ie. we threading along a nested
         # RST tree as go from sibling to sibling
-        targets = [t for _, t in dtree.deps[subtree]]
-        ranked_targets = attach_ranker.predict([(dtree, subtree, targets)])[0]
+        ranked_targets = dtree.deps(subtree)
         for tgt in ranked_targets:
-            src = walk(src, tgt, strategy)
+            src = walk(src, tgt)
         # ancestor is None in the case of the root node
-        return connect_trees(ancestor, src, rel) if ancestor else src
+        return connect_trees(ancestor, src, rel, nuc) if ancestor else src
 
     roots = dtree.real_roots_idx()
     if len(roots) == 1:
-        real_root = roots[0][1]  # roots is a list of (label, num)
-        rparts = walk(None, real_root, strategy)
+        real_root = roots[0]  # roots is a list of indices
+        rparts = walk(None, real_root)
     else:
         msg = ('Cannot convert RstDepTree to SimpleRSTTree, ',
                'multiple roots: {}'.format(roots))

--- a/educe/rst_dt/tests.py
+++ b/educe/rst_dt/tests.py
@@ -136,13 +136,13 @@ class RSTTest(unittest.TestCase):
         for lstr in lw_trees:
             rst1 = parse_lightweight_tree(lstr)
             dep = RstDepTree.from_simple_rst_tree(rst1)
-            rst2 = deptree_to_simple_rst_tree(dep, [])
+            rst2 = deptree_to_simple_rst_tree(dep)
             self.assertEqual(rst1, rst2, "round-trip on " + lstr)
 
         for name, tree in self._test_trees().items():
             rst1 = SimpleRSTTree.from_rst_tree(tree)
             dep = RstDepTree.from_simple_rst_tree(rst1)
-            rst2 = deptree_to_simple_rst_tree(dep, [])
+            rst2 = deptree_to_simple_rst_tree(dep)
             self.assertEqual(treenode(rst1).span,
                              treenode(rst2).span,
                              "span equality on " + name)
@@ -179,16 +179,16 @@ class RSTTest(unittest.TestCase):
             dep = RstDepTree.from_simple_rst_tree(rst1)
 
             dep_a = dep
-            rst2a = deptree_to_simple_rst_tree(dep_a, [])
+            rst2a = deptree_to_simple_rst_tree(dep_a)
             self.assertEqual(rst1, rst2a, "round-trip on " + lstr)
 
             dep_b = copy.deepcopy(dep)
-            dep_b.deps[0].reverse()
-            rst2b = deptree_to_simple_rst_tree(dep_b, [])
+            dep_b.deps(0).reverse()
+            rst2b = deptree_to_simple_rst_tree(dep_b)
 
             dep_c = copy.deepcopy(dep)
-            random.shuffle(dep_c.deps[0])
-            rst2c = deptree_to_simple_rst_tree(dep_c, [])
+            random.shuffle(dep_c.deps(0))
+            rst2c = deptree_to_simple_rst_tree(dep_c)
 
     def test_rst_to_dt_nuclearity_loss(self):
         """
@@ -222,10 +222,10 @@ class RSTTest(unittest.TestCase):
 
         # a little sanity check first
         dep0 = RstDepTree.from_simple_rst_tree(rst0)
-        rev0 = deptree_to_simple_rst_tree(dep0, ['r'])
+        rev0 = deptree_to_simple_rst_tree(dep0)  # was:, ['r'])
         self.assertEqual(rst0, rev0, "same structure " + nuked)  # sanity
 
         # now the real test
         dep1 = RstDepTree.from_simple_rst_tree(rst1)
-        rev1 = deptree_to_simple_rst_tree(dep1, ['r'])
+        rev1 = deptree_to_simple_rst_tree(dep1)  # was:, ['r'])
         # self.assertEqual(rst0, rev1, "same structure " + tricky)

--- a/setup.py
+++ b/setup.py
@@ -10,18 +10,20 @@ import sys
 
 PY3 = sys.version > '3'
 
-REQS = \
-    ['enum34',
-     'funcparserlib' if PY3 else 'funcparserlib == 0.3.6',
-     'pydot' if PY3 else 'pydot >= 1.0.28',
-     'python-graph-core',
-     'python-graph-dot',
-     'frozendict',
-     'sh',
-     'six',
-     'tabulate',
-     'nltk >= 3.0.0',
-     'soundex']
+REQS = [
+    'enum34',
+    'funcparserlib' if PY3 else 'funcparserlib == 0.3.6',
+    'pydot' if PY3 else 'pydot >= 1.0.28',
+    'python-graph-core',
+    'python-graph-dot',
+    'frozendict',
+    'sh',
+    'six',
+    'tabulate',
+    'nltk >= 3.0.0',
+    'soundex',
+    'pandas >= 0.16',
+]
 
 
 setup(name='educe',


### PR DESCRIPTION
This PR promotes rank and nuclearity to first-class citizens of an RstDepTree.
In direct connection with this, this PR adds various baseline classifiers to predict rank and nuclearity; those classifiers should eventually be moved to attelo or irit-rst-dt.

RstDepTrees with proper rank and nuclearity enable a fairer comparison between the outputs of attelo and CODRA. We now provide a loader for the output files of the latter.

This PR also introduces a new module dedicated to corpus analytics. Instances of relations are stored in a pandas DataFrame (which means we get a new requirement: pandas).