### PR TITLE
[MRG] FIX do not include Tstars in stac-util count for EDUs

### DIFF
--- a/educe/stac/annotation.py
+++ b/educe/stac/annotation.py
@@ -67,7 +67,10 @@ import warnings
 from educe.annotation import Unit, Relation, Schema
 import educe.glozz as glozz
 
-STRUCTURE_TYPES = ['Turn', 'paragraph', 'dialogue', 'Dialogue']
+# TODO cleanly integrate 'Tstar' in one of the following ?
+STRUCTURE_TYPES = ['Turn', 'paragraph',
+                   'dialogue', 'Dialogue',  # TODO remove one or keep both?
+]
 RESOURCE_TYPES = ['default', 'Resource']
 PREFERENCE_TYPES = ['Preference']
 

--- a/educe/stac/util/cmd/count.py
+++ b/educe/stac/util/cmd/count.py
@@ -22,7 +22,13 @@ import educe.stac
 SEGMENT_CATEGORIES = [("dialogue", educe.stac.is_dialogue),
                       ("turn star", lambda x: x.type == 'Tstar'),
                       ("turn", educe.stac.is_turn),
-                      ("edu", educe.stac.is_edu)]
+                      # temporary workaround to exclude Tstars from being
+                      # considered as EDUs
+                      # TODO update educe.stac.{annotation,context} to
+                      # cleanly integrate Tstars
+                      # MM: I cannot make an informed decision about this yet
+                      ("edu", lambda x: (educe.stac.is_edu(x) and
+                                         x.type != 'Tstar'))]
 
 
 LINK_CATEGORIES = [("rel insts", educe.stac.is_relation_instance),


### PR DESCRIPTION
This PR fixes the counting of EDUs for STAC.

The changes in 71b63a5 included Turn-stars in the count of EDUs, which is not intended.