### PR TITLE
[MRG] ENH pandas-based statistics module for the STAC corpus

### DIFF
--- a/educe/glozz.py
+++ b/educe/glozz.py
@@ -15,8 +15,9 @@ import codecs
 import xml.etree.ElementTree as ET
 import sys
 
-from educe.annotation import *
-from educe.internalutil import on_single_element, linebreak_xml
+from educe.annotation import (Span, RelSpan, Unit, Relation, Schema,
+                              Document)
+from educe.internalutil import on_single_element
 
 
 if sys.version > '3':
@@ -26,7 +27,8 @@ if sys.version > '3':
 _MINIDOM_ZERO = len(minidom.Document().toxml(encoding='utf-8')) + 1
 _GLOZZ_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="no"?>'
 
-class GlozzOutputSettings:
+
+class GlozzOutputSettings(object):
     """
     Non-essential aspects of Glozz XML output, such as the order that
     feature structures or metadata are written out.  Controlling these
@@ -38,20 +40,27 @@ class GlozzOutputSettings:
         self.fs_order = feature_order
         self.md_order = metadata_order
 
-default_output_settings = GlozzOutputSettings([],[])
+
+DEFAULT_OUTPUT_SETTINGS = GlozzOutputSettings([], [])
+
 
 class GlozzDocument(Document):
+    """Representation of a glozz document"""
+
     def __init__(self, hashcode, unit, rels, schemas, text):
         Document.__init__(self, unit, rels, schemas, text)
         self.hashcode = hashcode
 
-    def to_xml(self, settings=default_output_settings):
+    def to_xml(self, settings=DEFAULT_OUTPUT_SETTINGS):
         elm = ET.Element('annotations')
         if self.hashcode is not None:
             elm.append(ET.Element('metadata', corpusHashcode=self.hashcode))
-        elm.extend([glozz_annotation_to_xml(x, 'unit',     settings) for x in self.units])
-        elm.extend([glozz_annotation_to_xml(x, 'relation', settings) for x in self.relations])
-        elm.extend([glozz_annotation_to_xml(x, 'schema',   settings) for x in self.schemas])
+        elm.extend([glozz_annotation_to_xml(x, 'unit', settings)
+                    for x in self.units])
+        elm.extend([glozz_annotation_to_xml(x, 'relation', settings)
+                    for x in self.relations])
+        elm.extend([glozz_annotation_to_xml(x, 'schema', settings)
+                    for x in self.schemas])
         return elm
 
     def set_origin(self, origin):
@@ -59,16 +68,18 @@ class GlozzDocument(Document):
         for x in self.schemas:
             x.origin = origin
 
+
 def ordered_keys(preferred, d):
     """
     Keys from a dictionary starting with 'preferred' ones
     in the order of preference
     """
-    return [ k for k in preferred if k in d ] +\
-           [ k for k in d if k not in preferred ]
+    return ([k for k in preferred if k in d] +
+            [k for k in d if k not in preferred])
 
 
-def glozz_annotation_to_xml(self, tag='annotation', settings=default_output_settings):
+def glozz_annotation_to_xml(self, tag='annotation',
+                            settings=DEFAULT_OUTPUT_SETTINGS):
     meta_elm = ET.Element('metadata')
 
     for k in ordered_keys(settings.md_order, self.metadata):
@@ -79,43 +90,46 @@ def glozz_annotation_to_xml(self, tag='annotation', settings=default_output_sett
     char_elm = ET.Element('characterisation')
     char_tag_elm = ET.Element('type')
     char_tag_elm.text = self.type
-    char_tag_fs  = ET.Element('featureSet')
+    char_tag_fs = ET.Element('featureSet')
     for k in ordered_keys(settings.fs_order, self.features):
-        e = ET.Element('feature',name=k)
+        e = ET.Element('feature', name=k)
         e.text = self.features[k]
         char_tag_fs.append(e)
     char_elm.extend([char_tag_elm, char_tag_fs])
 
     elm = ET.Element(tag, id=self.local_id())
-    if (tag == 'unit'):
+    if tag == 'unit':
         span_elm = glozz_unit_to_span_xml(self)
-    elif (tag == 'relation'):
+    elif tag == 'relation':
         span_elm = glozz_relation_to_span_xml(self)
-    elif (tag == 'schema'):
+    elif tag == 'schema':
         span_elm = glozz_schema_to_span_xml(self)
     else:
         raise Exception("Don't know how to emit XML for non unit/relation annotations (%s)" % tag)
     elm.extend([meta_elm, char_elm, span_elm])
     return elm
 
+
 def glozz_unit_to_span_xml(self):
-    def set_pos(elm,x):
+    def set_pos(elm, x):
         elm.append(ET.Element('singlePosition', index=str(x)))
     elm = ET.Element('positioning')
     start_elm = ET.Element('start')
-    end_elm   = ET.Element('end')
+    end_elm = ET.Element('end')
     set_pos(start_elm, self.span.char_start)
-    set_pos(end_elm,   self.span.char_end)
+    set_pos(end_elm, self.span.char_end)
     elm.extend([start_elm, end_elm])
     return elm
 
+
 def glozz_relation_to_span_xml(self):
-    def set_pos(elm,x):
+    def set_pos(elm, x):
         elm.append(ET.Element('term', id=str(x)))
     elm = ET.Element('positioning')
-    set_pos(elm,self.span.t1)
-    set_pos(elm,self.span.t2)
+    set_pos(elm, self.span.t1)
+    set_pos(elm, self.span.t2)
     return elm
+
 
 def glozz_schema_to_span_xml(self):
     elm = ET.Element('positioning')
@@ -127,21 +141,21 @@ def glozz_schema_to_span_xml(self):
         elm.append(ET.Element('embedded-schema', id=str(x)))
     return elm
 
+
 # ---------------------------------------------------------------------
 # xml processing
 # -----------------------------------------------------------
-
 class GlozzException(Exception):
     def __init__(self, *args, **kw):
         Exception.__init__(self, *args, **kw)
 
+
 # ---------------------------------------------------------------------
 # glozz files
 # ---------------------------------------------------------------------
-
 def read_node(node, context=None):
     def get_one(name, default, ctx=None):
-        f = lambda n : read_node(n, ctx)
+        f = lambda n: read_node(n, ctx)
         return on_single_element(node, default, f, name)
 
     def get_all(name):
@@ -151,22 +165,22 @@ def read_node(node, context=None):
         hashcode = get_one('metadata', '', 'annotations')
         if hashcode is '':
             hashcode = None
-        units    = get_all('unit')
-        rels     = get_all('relation')
-        schemas  = get_all('schema')
+        units = get_all('unit')
+        rels = get_all('relation')
+        schemas = get_all('schema')
         return (hashcode, units, rels, schemas)
 
     elif node.tag == 'characterisation':
-        fs        = get_one('featureSet', {})
-        unit_type = get_one('type'      , None)
+        fs = get_one('featureSet', {})
+        unit_type = get_one('type', None)
         return (unit_type, fs)
 
     elif node.tag == 'feature':
-        attr=node.attrib['name']
-        val =node.text.strip() if node.text else None
+        attr = node.attrib['name']
+        val = node.text.strip() if node.text else None
         return (attr, val)
 
-    ## TODO throw exception if we see more than one instance of a key
+    # TODO throw exception if we see more than one instance of a key
     elif node.tag == 'featureSet':
         return dict(get_all('feature'))
 
@@ -174,39 +188,41 @@ def read_node(node, context=None):
         return node.attrib['corpusHashcode']
 
     elif node.tag == 'metadata':
-        return dict([(t.tag,t.text.strip()) for t in node ])
+        return dict([(t.tag, t.text.strip()) for t in node])
 
     elif node.tag == 'positioning' and context == 'unit':
         start = get_one('start', None)
-        end   = get_one('end',   None)
-        return Span(start,end)
+        end = get_one('end', None)
+        return Span(start, end)
 
     elif node.tag == 'positioning' and context == 'relation':
         terms = get_all('term')
         if len(terms) != 2:
-            raise GlozzException("Was expecting exactly 2 terms, but got %d" % len(terms))
+            raise GlozzException(
+                "Was expecting exactly 2 terms, but got %d" % len(terms))
         else:
             return RelSpan(terms[0], terms[1])
 
     elif node.tag == 'positioning' and context == 'schema':
-        units     = frozenset(get_all('embedded-unit'))
+        units = frozenset(get_all('embedded-unit'))
         relations = frozenset(get_all('embedded-relation'))
-        schemas   = frozenset(get_all('embedded-schema'))
+        schemas = frozenset(get_all('embedded-schema'))
         return units, relations, schemas
 
     elif node.tag == 'relation':
-        rel_id          = node.attrib['id']
+        rel_id = node.attrib['id']
         (unit_type, fs) = get_one('characterisation', None)
-        span            = get_one('positioning',      None, 'relation')
-        metadata        = get_one('metadata',         {})
+        span = get_one('positioning', None, 'relation')
+        metadata = get_one('metadata', {})
         return Relation(rel_id, span, unit_type, fs, metadata=metadata)
 
     if node.tag == 'schema':
-        anno_id         = node.attrib['id']
+        anno_id = node.attrib['id']
         (anno_type, fs) = get_one('characterisation', None)
-        units, rels, schemas = get_one('positioning',      None, 'schema')
-        metadata        = get_one('metadata',         {})
-        return Schema(anno_id, units, rels, schemas, anno_type, fs, metadata=metadata)
+        units, rels, schemas = get_one('positioning', None, 'schema')
+        metadata = get_one('metadata', {})
+        return Schema(anno_id, units, rels, schemas, anno_type, fs,
+                      metadata=metadata)
 
     elif node.tag == 'singlePosition':
         return int(node.attrib['index'])
@@ -214,17 +230,18 @@ def read_node(node, context=None):
     elif node.tag == 'start' or node.tag == 'end':
         return get_one('singlePosition', None)
 
-    elif node.tag in [ 'term', 'embedded-unit', 'embedded-relation', 'embedded-schema' ]:
+    elif node.tag in ['term', 'embedded-unit', 'embedded-relation',
+                      'embedded-schema']:
         return node.attrib['id']
 
     elif node.tag == 'type':
         return node.text.strip()
 
     elif node.tag == 'unit':
-        unit_id         = node.attrib['id']
+        unit_id = node.attrib['id']
         (unit_type, fs) = get_one('characterisation', None)
-        span            = get_one('positioning',      None, 'unit')
-        metadata        = get_one('metadata',         {})
+        span = get_one('positioning', None, 'unit')
+        metadata = get_one('metadata', {})
         return Unit(unit_id, span, unit_type, fs, metadata=metadata)
 
 
@@ -241,6 +258,7 @@ def read_annotation_file(anno_filename, text_filename=None):
             text = tf.read()
     return GlozzDocument(hashcode, units, rels, schemas, text)
 
+
 def hashcode(f):
     """
     Hashcode mechanism as documented in the Glozz manual appendix.
@@ -255,11 +273,13 @@ def hashcode(f):
         length += 1
         if byte and byte != 0:
             code *= ord(byte)
-            code =  code % long(99999999)
+            code = code % long(99999999)
         byte = f.read(1)
     return str(length) + '-' + str(code)
 
-def write_annotation_file(anno_filename, doc, settings=default_output_settings):
+
+def write_annotation_file(anno_filename, doc,
+                          settings=DEFAULT_OUTPUT_SETTINGS):
     """
     Write a GlozzDocument to XML in the given path
     """

--- a/educe/glozz.py
+++ b/educe/glozz.py
@@ -283,9 +283,8 @@ def write_annotation_file(anno_filename, doc,
     """
     Write a GlozzDocument to XML in the given path
     """
-
     elem = doc.to_xml(settings=settings)
-    string1 = ET.tostring(elem, 'utf-8')
+    string1 = ET.tostring(elem, encoding='utf-8')
     # contortion 1: write, then read and print from minidom to match
     # whitespace on closing tags (we're trying to match glozz output
     # as much as possible so as to avoid introducing spurious
@@ -296,4 +295,7 @@ def write_annotation_file(anno_filename, doc,
     # closely matches Glozz
     with codecs.open(anno_filename, 'wb', 'utf-8') as fout:
         print(_GLOZZ_DECL, file=fout)
-        fout.write(string2[_MINIDOM_ZERO:])
+        # we have to decode('utf-8') first, because
+        # codecs expects Unicode strings to encode them to UTF-8
+        out_str = string2[_MINIDOM_ZERO:].decode('utf-8')
+        fout.write(out_str)

--- a/educe/stac/annotation.py
+++ b/educe/stac/annotation.py
@@ -67,39 +67,45 @@ import warnings
 from educe.annotation import Unit, Relation, Schema
 import educe.glozz as glozz
 
-# TODO cleanly integrate 'Tstar' in one of the following ?
-STRUCTURE_TYPES = ['Turn', 'paragraph',
-                   'dialogue', 'Dialogue',  # TODO remove one or keep both?
+
+STRUCTURE_TYPES = [
+    'Turn',
+    'Tstar',  # sequence of turns with same speaker
+    'paragraph',
+    'dialogue', 'Dialogue',  # TODO remove one or keep both?
 ]
 RESOURCE_TYPES = ['default', 'Resource']
 PREFERENCE_TYPES = ['Preference']
 
-SUBORDINATING_RELATIONS = \
-    ['Explanation',
-     'Background',
-     'Elaboration',
-     'Correction',
-     'Q-Elab',
-     'Comment',
-     'Question-answer_pair',
-     'Clarification_question',
-     'Acknowledgement']
+SUBORDINATING_RELATIONS = [
+    'Explanation',
+    'Background',
+    'Elaboration',
+    'Correction',
+    'Q-Elab',
+    'Comment',
+    'Question-answer_pair',
+    'Clarification_question',
+    'Acknowledgement'
+]
 
-COORDINATING_RELATIONS = \
-    ['Result',
-     'Narration',
-     'Continuation',
-     'Contrast',
-     'Parallel',
-     'Conditional',
-     'Alternation']
+COORDINATING_RELATIONS = [
+    'Result',
+    'Narration',
+    'Continuation',
+    'Contrast',
+    'Parallel',
+    'Conditional',
+    'Alternation'
+]
 
-DIALOGUE_ACTS =\
-    ['Offer',
-     'Counteroffer',
-     'Accept',
-     'Refusal',
-     'Other']
+DIALOGUE_ACTS = [
+    'Offer',
+    'Counteroffer',
+    'Accept',
+    'Refusal',
+    'Other'
+]
 
 _F_ADDRESSEE = 'Addressee'
 
@@ -124,8 +130,8 @@ def split_turn_text(text):
     else:
         # it's easy to just return the body here, but when this arises
         # it's a sign that something weird has happened
-        raise Exception("Turn does not start with number/speaker prefix: "
-                        + text)
+        raise Exception("Turn does not start with number/speaker prefix: " +
+                        text)
 
 
 def turn_id(anno):
@@ -174,8 +180,10 @@ def set_addressees(anno, addr):
 # ---------------------------------------------------------------------
 
 
-RENAMES = {'Strategic_comment': 'Other',
-           'Segment': 'Other'}
+RENAMES = {
+    'Strategic_comment': 'Other',
+    'Segment': 'Other'
+}
 "Dialogue acts that should be treated as a different one"
 
 
@@ -212,32 +220,40 @@ def is_resource(annotation):
     """
     See Unit typology above
     """
-    return isinstance(annotation, Unit) and\
-        annotation.type in RESOURCE_TYPES
+    return (isinstance(annotation, Unit) and
+            annotation.type in RESOURCE_TYPES)
 
 
 def is_preference(annotation):
     """
     See Unit typology above
     """
-    return isinstance(annotation, Unit) and\
-        annotation.type in PREFERENCE_TYPES
+    return (isinstance(annotation, Unit) and
+            annotation.type in PREFERENCE_TYPES)
 
 
 def is_turn(annotation):
     """
     See Unit typology above
     """
-    return isinstance(annotation, Unit) and\
-        annotation.type == 'Turn'
+    return (isinstance(annotation, Unit) and
+            annotation.type == 'Turn')
+
+
+def is_turn_star(annotation):
+    """
+    See Unit typology above
+    """
+    return (isinstance(annotation, Unit) and
+            annotation.type == 'Tstar')
 
 
 def is_dialogue(annotation):
     """
     See Unit typology above
     """
-    return isinstance(annotation, Unit) and\
-        annotation.type == 'Dialogue'
+    return (isinstance(annotation, Unit) and
+            annotation.type == 'Dialogue')
 
 
 def is_edu(annotation):
@@ -245,41 +261,41 @@ def is_edu(annotation):
     See Unit typology above
     """
     blacklist = STRUCTURE_TYPES + RESOURCE_TYPES + PREFERENCE_TYPES
-    return isinstance(annotation, Unit) and\
-        annotation.type not in blacklist
+    return (isinstance(annotation, Unit) and
+            annotation.type not in blacklist)
 
 
 def is_relation_instance(annotation):
     """
     See Relation typology above
     """
-    return isinstance(annotation, Relation) and\
-        annotation.type in SUBORDINATING_RELATIONS or\
-        annotation.type in COORDINATING_RELATIONS
+    return (isinstance(annotation, Relation) and
+            annotation.type in SUBORDINATING_RELATIONS or
+            annotation.type in COORDINATING_RELATIONS)
 
 
 def is_subordinating(annotation):
     """
     See Relation typology above
     """
-    return isinstance(annotation, Relation) and\
-        annotation.type in SUBORDINATING_RELATIONS
+    return (isinstance(annotation, Relation) and
+            annotation.type in SUBORDINATING_RELATIONS)
 
 
 def is_coordinating(annotation):
     """
     See Relation typology above
     """
-    return isinstance(annotation, Relation) and\
-        annotation.type in COORDINATING_RELATIONS
+    return (isinstance(annotation, Relation) and
+            annotation.type in COORDINATING_RELATIONS)
 
 
 def is_cdu(annotation):
     """
     See CDUs typology above
     """
-    return isinstance(annotation, Schema) and\
-        annotation.type == 'Complex_discourse_unit'
+    return (isinstance(annotation, Schema) and
+            annotation.type == 'Complex_discourse_unit')
 
 
 def is_dialogue_act(annotation):
@@ -295,8 +311,8 @@ def is_structure(annotation):
     Is one of the document-structure annotations, something an
     annotator is expected not to edit, create, delete
     """
-    return isinstance(annotation, Unit) and\
-        annotation.type in STRUCTURE_TYPES
+    return (isinstance(annotation, Unit) and
+            annotation.type in STRUCTURE_TYPES)
 
 
 def cleanup_comments(anno):
@@ -362,57 +378,58 @@ def speaker(anno):
 # Adding annotations
 # ---------------------------------------------------------------------
 
-STAC_GLOZZ_FS_ORDER = \
-    ['Status',
-     'Quantity',
-     'Correctness',
-     'Kind',
-     'Comments',
-     'Developments',
-     'Emitter',
-     'Identifier',
-     'Timestamp',
-     'Resources',
-     'Trades',
-     'Dice_rolling',
-     'Gets',
-     'Has_resources',
-     'Amount_of_resources',
-     'Addressee',
-     'Surface_act']
+STAC_GLOZZ_FS_ORDER = [
+    'Status',
+    'Quantity',
+    'Correctness',
+    'Kind',
+    'Comments',
+    'Developments',
+    'Emitter',
+    'Identifier',
+    'Timestamp',
+    'Resources',
+    'Trades',
+    'Dice_rolling',
+    'Gets',
+    'Has_resources',
+    'Amount_of_resources',
+    'Addressee',
+    'Surface_act'
+]
 
-STAC_UNANNOTATED_FS_ORDER = \
-    ['Status',
-     'Quantity',
-     'Correctness',
-     'Kind',
-     'Identifier',
-     'Timestamp',
-     'Emitter',
-     'Resources',
-     'Developments',
-     'Comments',
-     'Dice_rolling',
-     'Gets',
-     'Trades',
-     'Has_resources',
-     'Amount_of_resources',
-     'Addressee',
-     'Surface_act']
+STAC_UNANNOTATED_FS_ORDER = [
+    'Status',
+    'Quantity',
+    'Correctness',
+    'Kind',
+    'Identifier',
+    'Timestamp',
+    'Emitter',
+    'Resources',
+    'Developments',
+    'Comments',
+    'Dice_rolling',
+    'Gets',
+    'Trades',
+    'Has_resources',
+    'Amount_of_resources',
+    'Addressee',
+    'Surface_act'
+]
 
-STAC_MD_ORDER = \
-    ['author',
-     'creation-date',
-     'lastModifier',
-     'lastModificationDate']
+STAC_MD_ORDER = [
+    'author',
+    'creation-date',
+    'lastModifier',
+    'lastModificationDate'
+]
 
-STAC_OUTPUT_SETTINGS = \
-    glozz.GlozzOutputSettings(STAC_GLOZZ_FS_ORDER,
-                              STAC_MD_ORDER)
+STAC_OUTPUT_SETTINGS = glozz.GlozzOutputSettings(
+    STAC_GLOZZ_FS_ORDER, STAC_MD_ORDER)
 
-STAC_UNANNOTATED_OUTPUT_SETTINGS = \
-    glozz.GlozzOutputSettings(STAC_UNANNOTATED_FS_ORDER,
-                              STAC_MD_ORDER)
+STAC_UNANNOTATED_OUTPUT_SETTINGS = glozz.GlozzOutputSettings(
+    STAC_UNANNOTATED_FS_ORDER, STAC_MD_ORDER)
 
 
 # Deprecated

--- a/educe/stac/context.py
+++ b/educe/stac/context.py
@@ -59,6 +59,8 @@ def _blank_out(text, rejects):
     return text2
 
 
+# FIXME produce proper turn-stars, with type 'Tstar'
+# MM: not sure what side-effects this could produce as of 2015-10-20
 def merge_turn_stars(doc):
     """Return a copy of the document in which consecutive turns
     by the same speaker have been merged.

--- a/educe/stac/util/cmd/count.py
+++ b/educe/stac/util/cmd/count.py
@@ -500,7 +500,7 @@ def main(args):
     print(tabulate(rows, headers=headers))
 
     # additional info
-    if False:
+    if True:
         # empty CDUs: call stac-oneoff clean-schemas
         empty_cdus = [cs for cs in cdu_stats
                       if cs[-1] == 0]
@@ -508,6 +508,15 @@ def main(args):
             print('Empty CDUs !?')
             print('\n'.join(str(cs)
                             for cs in sorted(empty_cdus,
+                                             key=lambda c: (c[1], c[2]))))
+
+        # CDUs with one member: call ???
+        mono_member_cdus = [cs for cs in cdu_stats
+                            if cs[-1] == 1]
+        if mono_member_cdus:
+            print('CDUs with a unique member !?')
+            print('\n'.join(str(cs)
+                            for cs in sorted(mono_member_cdus,
                                              key=lambda c: (c[1], c[2]))))
     if False:
         # CDUs occurring at the same level (nb_cdus_tot > max_lvl)

--- a/educe/stac/util/cmd/count.py
+++ b/educe/stac/util/cmd/count.py
@@ -422,6 +422,59 @@ def cdu_statistics(corpus):
                     cdus.append(row)
 
     return cdus
+
+
+def cdu_report(cdu_stats):
+    """Generate a string that contains reports on CDUs"""
+    # detailed info on CDUs
+    headers = ['CDUs', 'min', 'max', 'mean', 'median']
+    rows = []
+    # EDUs
+    nb_edus_tot = [cs[-1] for cs in cdu_stats]
+    mean_nb_edus_tot, median_nb_edus_tot = rounded_mean_median(nb_edus_tot)
+    min_nb_edus_tot = min(nb_edus_tot)
+    max_nb_edus_tot = max(nb_edus_tot)
+    rows.append(['# EDUs',
+                 min_nb_edus_tot, max_nb_edus_tot,
+                 mean_nb_edus_tot, median_nb_edus_tot])
+    # degree of nesting
+    max_lvls = [cs[-2] for cs in cdu_stats]
+    mean_lvl, median_lvl = rounded_mean_median(max_lvls)
+    min_max_lvl = min(max_lvls)
+    max_max_lvl = max(max_lvls)
+    rows.append(['deg. nesting',
+                 min_max_lvl, max_max_lvl,
+                 mean_lvl, median_lvl])
+    res = tabulate(rows, headers=headers)
+
+    # additional info
+    if True:
+        # empty CDUs: call stac-oneoff clean-schemas
+        empty_cdus = [cs for cs in cdu_stats
+                      if cs[-1] == 0]
+        if empty_cdus:
+            print('Empty CDUs !?')
+            print('\n'.join(str(cs)
+                            for cs in sorted(empty_cdus,
+                                             key=lambda c: (c[1], c[2]))))
+            print()
+        # CDUs with one member: call ???
+        mono_member_cdus = [cs for cs in cdu_stats
+                            if cs[-1] == 1]
+        if mono_member_cdus:
+            print('CDUs with a unique member !?')
+            print('\n'.join(str(cs)
+                            for cs in sorted(mono_member_cdus,
+                                             key=lambda c: (c[1], c[2]))))
+            print()
+    if False:
+        # CDUs occurring at the same level (nb_cdus_tot > max_lvl)
+        same_lvl_cdus = [cs for cs in cdu_stats
+                         if cs[-3] > cs[-2]]
+        print(same_lvl_cdus)
+        print()
+
+    return res
 # end EXPERIMENTAL: CDU stuff
 
 
@@ -476,51 +529,7 @@ def main(args):
     print(report(dcounts, gcounts, gcounts2, acounts))
 
     # EXPERIMENTAL
-    print('\n')
     cdu_stats = cdu_statistics(corpus)
-    # detailed info on CDUs
-    headers = ['CDUs', 'min', 'max', 'mean', 'median']
-    rows = []
-    # EDUs
-    nb_edus_tot = [cs[-1] for cs in cdu_stats]
-    mean_nb_edus_tot, median_nb_edus_tot = rounded_mean_median(nb_edus_tot)
-    min_nb_edus_tot = min(nb_edus_tot)
-    max_nb_edus_tot = max(nb_edus_tot)
-    rows.append(['# EDUs',
-                 min_nb_edus_tot, max_nb_edus_tot,
-                 mean_nb_edus_tot, median_nb_edus_tot])
-    # degree of nesting
-    max_lvls = [cs[-2] for cs in cdu_stats]
-    mean_lvl, median_lvl = rounded_mean_median(max_lvls)
-    min_max_lvl = min(max_lvls)
-    max_max_lvl = max(max_lvls)
-    rows.append(['deg. nesting',
-                 min_max_lvl, max_max_lvl,
-                 mean_lvl, median_lvl])
-    print(tabulate(rows, headers=headers))
-
-    # additional info
-    if True:
-        # empty CDUs: call stac-oneoff clean-schemas
-        empty_cdus = [cs for cs in cdu_stats
-                      if cs[-1] == 0]
-        if empty_cdus:
-            print('Empty CDUs !?')
-            print('\n'.join(str(cs)
-                            for cs in sorted(empty_cdus,
-                                             key=lambda c: (c[1], c[2]))))
-
-        # CDUs with one member: call ???
-        mono_member_cdus = [cs for cs in cdu_stats
-                            if cs[-1] == 1]
-        if mono_member_cdus:
-            print('CDUs with a unique member !?')
-            print('\n'.join(str(cs)
-                            for cs in sorted(mono_member_cdus,
-                                             key=lambda c: (c[1], c[2]))))
-    if False:
-        # CDUs occurring at the same level (nb_cdus_tot > max_lvl)
-        same_lvl_cdus = [cs for cs in cdu_stats
-                         if cs[-3] > cs[-2]]
-        print(same_lvl_cdus)
+    print('\n')
+    print(cdu_report(cdu_stats))
     # end EXPERIMENTAL

--- a/educe/stac/util/cmd/pd_count.py
+++ b/educe/stac/util/cmd/pd_count.py
@@ -5,9 +5,35 @@
 from __future__ import print_function
 
 import pandas as pd
+from tabulate import tabulate
 
-from educe.stac.annotation import is_cdu, is_edu, is_relation_instance
+from educe.stac.annotation import (is_cdu, is_dialogue, is_edu,
+                                   is_relation_instance, is_turn,
+                                   is_turn_star)
 from educe.stac.context import Context
+
+
+# cc'ed from count
+SEGMENT_CATEGORIES = [("dialogue", is_dialogue),
+                      ("turn star", is_turn_star),
+                      ("turn", is_turn),
+                      ("edu", is_edu)]
+
+
+LINK_CATEGORIES = [("rel insts", is_relation_instance),
+                   ("CDUs", is_cdu)]
+
+
+def big_banner(string, width=60):
+    """
+    Convert a string into a large banner ::
+
+       foo
+       ========================================
+
+    """
+    return "\n".join([string, "=" * width, ""])
+# end cc'ed
 
 
 def rel_feats(doc, ctx, anno, debug=False):
@@ -127,22 +153,74 @@ def rel_feats(doc, ctx, anno, debug=False):
     return res
 
 
+def dlg_feats(anno):
+    """Get Dialogue features."""
+    span_char_len = anno.span.char_end - anno.span.char_start
+    res = {
+        'span_char_len': span_char_len,
+    }
+    # TODO maybe extend the dict with anno.features.items()
+    # TODO span_tok_len: length in tokens (need info from CoreNLP)
+    return res
+
+
+def edu_feats(doc, ctx, anno):
+    """Get EDU features."""
+    span_char_len = anno.span.char_end - anno.span.char_start
+    turn = ctx[anno].turn.identifier()
+    tstar = ctx[anno].tstar.identifier()
+    dialogue = ctx[anno].dialogue.identifier()
+    res = {
+        'span_char_len': span_char_len,
+        'turn': turn,
+        'tstar': tstar,
+        'dialogue': dialogue,
+    }
+
+    # TODO maybe extend the dict with anno.features.items()
+    # TODO span_tok_len: length in tokens (need info from CoreNLP)
+    return res
+
+
+def turn_feats(anno):
+    """Get Turn features."""
+    span_char_len = anno.span.char_end - anno.span.char_start
+    res = {
+        'span_char_len': span_char_len,
+    }
+    # TODO maybe extend the dict with anno.features.items()
+    # TODO span_tok_len: length in tokens (need info from CoreNLP)
+    return res
+
+
+def tstar_feats(anno):
+    """Get turn-star features."""
+    span_char_len = anno.span.char_end - anno.span.char_start
+    res = {
+        'span_char_len': span_char_len,
+    }
+    # TODO maybe extend the dict with anno.features.items()
+    # TODO span_tok_len: length in tokens (need info from CoreNLP)
+    return res
+
+
 def cdu_feats(anno):
     """Get CDU features that are not immediate.
 
+    Parameters
+    ----------
+    anno: Schema
+        The schema that codes this CDU in the glozz format
+
     Returns
     -------
-    nb_edus_tot: int
-        Total number of EDUs spanned by this CDU.
-
-    nb_cdus_imm: int
-        Number of CDUs immediately embedded in this CDU.
-
-    nb_cdus_tot: int
-        Total number of CDUs recursively embedded in this CDU.
-
-    max_lvl: int
-        Maximal degree of CDU nesting in this CDU.
+    res: dict(string, int)
+        Features on this CDU, currently
+        'nb_edus_tot' (total number of EDUs spanned by this CDU),
+        'nb_cdus_imm' (number of CDUs immediately embedded in this CDU),
+        'nb_cdus_tot' (total number of CDUs recursively embedded in this
+        CDU),
+        'max_lvl' (maximal degree of CDU nesting in this CDU).
     """
     nb_members = len(anno.members)
     nb_cdus_imm = len([m for m in anno.members if is_cdu(m)])
@@ -167,17 +245,17 @@ def cdu_feats(anno):
                 raise ValueError('Unexpected type for a CDU member')
 
     # TODO new features:
-    # * nb_gaps: CDUs spans can be discontiguous
+    # * nb_gaps: CDUs spans can be discontinuous
     # * gap_max_len: max len of a gap (in #EDUs)
     # * over_nb_turns: nb of turns this CDU (partly) spans over
     # * over_nb_tstars: nb of tstars this CDU (partly) spans over
 
     res = {
-        'nb_members': nb_members,
-        'nb_cdus_imm': nb_cdus_imm,
-        'nb_cdus_tot': nb_cdus_tot,
-        'max_lvl': max_lvl,
-        'nb_edus_tot': nb_edus_tot,
+        'members': nb_members,
+        'members_cdu': nb_cdus_imm,
+        'spanned_cdus': nb_cdus_tot,
+        'spanned_edus': nb_edus_tot,
+        'depth': max_lvl,
     }
 
     return res
@@ -188,11 +266,13 @@ def create_dfs(corpus):
 
     Returns
     -------
-    cdus:
-    rels:
+    res: dict(string, DataFrame)
+        A DataFrame for each kind of structure present in the corpus.
     """
-    cdu_data = []
-    rel_data = []
+    rows = {anno_type: list()
+            for anno_type in ['edu', 'turn', 'tstar', 'dialogue',
+                              'cdu', 'rel']}
+
     for file_id, doc in corpus.items():
         # common stuff: get general info (doc, subdoc, annotator)
         doc_name = file_id.doc
@@ -201,26 +281,230 @@ def create_dfs(corpus):
         annotator = file_id.annotator
         # context: yerk
         ctx = Context.for_edus(doc)
-        #
+        # doc.annotations() := doc.units + doc.relations + doc.schemas
         for anno in doc.annotations():
             common_cols = {
-                'anno_id': anno._anno_id,  # TODO get another way (hidden attribute)
+                'anno_id': anno.identifier(),
                 'doc': doc_name,
                 'subdoc': subdoc_name,
                 'stage': stage,
                 'annotator': annotator,
                 'type': anno.type,  # ? maybe not
             }
-            if is_cdu(anno):
+            if is_edu(anno):
+                row = dict(common_cols.items() +
+                           edu_feats(doc, ctx, anno).items())
+                rows['edu'].append(row)
+            elif is_cdu(anno):
                 row = dict(common_cols.items() +
                            cdu_feats(anno).items())
-                cdu_data.append(row)
+                rows['cdu'].append(row)
             elif is_relation_instance(anno):
                 row = dict(common_cols.items() +
                            rel_feats(doc, ctx, anno).items())
-                rel_data.append(row)
-    # create dataframes
-    cdus = pd.DataFrame(data=cdu_data)
-    rels = pd.DataFrame(data=rel_data)
+                rows['rel'].append(row)
+            elif is_dialogue(anno):
+                row = dict(common_cols.items() +
+                           dlg_feats(anno).items())
+                rows['dialogue'].append(row)
+            elif is_turn(anno):
+                row = dict(common_cols.items() +
+                           turn_feats(anno).items())
+                rows['turn'].append(row)
+            elif is_turn_star(anno):
+                row = dict(common_cols.items() +
+                           tstar_feats(anno).items())
+                rows['tstar'].append(row)
+            elif anno.type in ['paragraph',
+                               'Resource', 'Anaphora',
+                               'Several_resources', 'Preference']:
+                # each paragraph (normally) corresponds to a Turn
+                # so just ignore them ;
+                # the situation is less clear-cut for 'Resource',
+                # 'Anaphora', 'Several_resources'
+                continue
+            else:
+                raise ValueError('Unsupported annotation: {}'.format(anno))
 
-    return cdus, rels
+    res = {anno_type: pd.DataFrame(data=row_list)
+           for anno_type, row_list in rows.items()
+           if row_list}
+
+    return res
+
+
+def report_on_corpus(corpus):
+    """Prepare and print a report on this corpus."""
+    # TODO create separate sets of DataFrames for "unannotated", "discourse"
+    # and "units"
+    dfs = create_dfs(corpus)
+    # invariant info
+    turns = dfs['turn']
+    # FIXME make turn-stars an integral part of a document, so they always
+    # exist...
+    if 'tstar' in dfs:
+        tstars = dfs['tstar']  # maybe not so invariant
+    # pre-annotation (seldom readjusted)
+    edus = dfs['edu']
+    dialogues = dfs['dialogue']
+    # annotation
+    rels = dfs['rel']
+    disc_rels = rels[rels['stage'] == 'discourse']
+    # pd.util.testing.assert_frame_equal(rels, disc_rels)
+    # FIXME this assertion fails for TEST: a document has
+    # an "Elaboration" relation in units/SILVER (!?) ; this is
+    # probably an error from the annotation process
+    cdus = dfs['cdu']
+    disc_cdus = cdus[cdus['stage'] == 'discourse']
+    # pd.util.testing.assert_frame_equal(cdus, disc_cdus)
+    # TODO maybe all EDUs from "units" are not acts? should we filter?
+    acts = edus[edus['stage'] == 'units']
+
+    # invariant info
+    ua_turns = turns[turns['stage'] == 'unannotated']
+    if 'tstar' in dfs:
+        ua_tstars = tstars[tstars['stage'] == 'unannotated']
+    # pre-annotation should be invariant to the annotation process
+    ua_edus = edus[edus['stage'] == 'unannotated']
+    ua_dialogues = dialogues[dialogues['stage'] == 'unannotated']
+    # discourse annotation
+    ds_edus = edus[edus['stage'] == 'discourse']
+
+    # Document structure
+    # ==================
+    # computed on the "unannotated" layer, more precisely its EDUs
+    # (with their context)
+    print(big_banner('Document structure'))
+
+    # per document
+    print('Per document')
+    all_stats = []
+    for col_name in ['subdoc', 'dialogue', 'tstar', 'turn', 'anno_id']:
+        cn_df = ua_edus[['doc', col_name]].drop_duplicates()
+        if col_name == 'anno_id':
+            cn_df.rename(columns={'anno_id': 'edu'}, inplace=True)
+        cn_stats = cn_df.groupby('doc').count().describe()
+        cn_stats_s = cn_stats.unstack().unstack()
+        cn_stats_s['total'] = cn_df.count()
+        all_stats.append(cn_stats_s)
+    print(pd.concat(all_stats))
+    print()
+
+    # per dialogue
+    print('Per dialogue')
+    all_stats = []
+    for col_name in ['tstar', 'turn', 'anno_id']:
+        cn_df = ua_edus[['dialogue', col_name]].drop_duplicates()
+        if col_name == 'anno_id':
+            cn_df.rename(columns={'anno_id': 'edu'}, inplace=True)
+        cn_stats = cn_df.groupby('dialogue').count().describe()
+        cn_stats_s = cn_stats.unstack().unstack()
+        cn_stats_s['total'] = cn_df.count()
+        all_stats.append(cn_stats_s)
+    print(pd.concat(all_stats))
+    print()
+
+    # per dialogue (2+ EDUs)
+    print('Per dialogue (2+ EDUs)')
+    # filter ua_edus for dialogues with 2+ EDUs: group by dialogue,
+    # then filter groups with only one entry
+    ua_edus_2p = ua_edus.groupby('dialogue').filter(lambda x: len(x) > 1)
+    # gather stats
+    all_stats = []
+    for col_name in ['tstar', 'turn', 'anno_id']:
+        cn_df = ua_edus_2p[['dialogue', col_name]].drop_duplicates()
+        if col_name == 'anno_id':
+            cn_df.rename(columns={'anno_id': 'edu'}, inplace=True)
+        cn_stats = cn_df.groupby('dialogue').count().describe()
+        cn_stats_s = cn_stats.unstack().unstack()
+        cn_stats_s['total'] = cn_df.count()
+        all_stats.append(cn_stats_s)
+    print(pd.concat(all_stats))
+    print()
+
+    # on the discourse layer
+    # per annotator
+    headers_ator = ["annotator", "doc", "subdoc", "dialogue",
+                    "turn star", "turn", "edu"]
+    rows_ator = [[name,
+                  group['doc'].nunique(),
+                  group.drop_duplicates(['doc', 'subdoc'])['subdoc'].count(),
+                  group['dialogue'].nunique(),
+                  group['tstar'].nunique(),
+                  group['turn'].nunique(),
+                  group['anno_id'].nunique()]
+                 for name, group in ds_edus.groupby('annotator')]
+    rows_ator.append([
+        "all together",
+        ds_edus['doc'].nunique(),
+        ds_edus.drop_duplicates(['doc', 'subdoc'])['subdoc'].count(),
+        ds_edus['dialogue'].nunique(),
+        ds_edus['tstar'].nunique(),
+        ds_edus['turn'].nunique(),
+        ds_edus['anno_id'].nunique(),
+    ])
+    # print these tables
+    print(tabulate(rows_ator, headers=headers_ator))
+    print()
+
+    # Dialogue acts
+    # =============
+    print(big_banner("Dialogue acts"))
+
+    acts_annot = acts.groupby('annotator')['type']
+    print(acts_annot.count())
+    print()
+    print(acts_annot.value_counts())
+    print()
+
+    # Links (per annotator)
+    # =====================
+    print(big_banner('Links'))
+    # CDUs
+    print('CDUs: number of members')
+    print('-----------------------')
+    print(disc_cdus['members'].describe().to_frame().unstack().unstack())
+    print(disc_cdus.groupby('annotator')['members'].describe().unstack())
+    print()
+    # rels
+    print('Relation instances: length (in EDUs)')
+    print('------------------------------------')
+    print(disc_rels['edu_dist'].describe().to_frame().unstack().unstack())
+    print(disc_rels.groupby('annotator')['edu_dist'].describe().unstack())
+    print()
+
+    # Relation instances
+    # ==================
+    print(big_banner("Relation instances"))
+
+    print('Distribution of relations')
+    print(disc_rels['type'].value_counts())
+    print()
+    print(disc_rels.groupby(['annotator'])['type'].value_counts())
+    print()
+
+    # additional tables
+    print('Relation length (in EDUs)')
+    rel_edist = disc_rels.groupby('type')['edu_dist'].describe().unstack()
+    print(rel_edist.sort_values(by='count', ascending=False))
+    print()
+
+    print('Relation length (in Turn-stars)')
+    rel_tdist = disc_rels.groupby('type')['tstar_dist'].describe().unstack()
+    print(rel_tdist.sort_values(by='count', ascending=False))
+    print()
+
+    print('Type of endpoints')
+    rel_by_endpoints = disc_rels.groupby(['src_type', 'tgt_type'])
+    rel_by_endpoints_stats = rel_by_endpoints['edu_dist'].describe()
+    print(rel_by_endpoints_stats.unstack()['count'].to_frame())
+    print()
+    if False:
+        print('Type of endpoints, by relation')
+        print(rel_by_endpoints['type'].value_counts().to_frame())
+        print()
+
+    # CDUs
+    # ====
+    print(big_banner("CDUs"))
+    print(disc_cdus.describe().transpose())

--- a/educe/stac/util/cmd/pd_count.py
+++ b/educe/stac/util/cmd/pd_count.py
@@ -1,0 +1,226 @@
+"""Statistical description of the corpus: EDUs, CDUs, relations.
+
+"""
+
+from __future__ import print_function
+
+import pandas as pd
+
+from educe.stac.annotation import is_cdu, is_edu, is_relation_instance
+from educe.stac.context import Context
+
+
+def rel_feats(doc, ctx, anno, debug=False):
+    """Get features for relations.
+
+    Parameters
+    ----------
+    doc:
+    ctx:
+    anno:
+
+    Returns
+    -------
+    res: dict
+        Features for this relation
+    """
+    # get all EDUs from document, sorted by their span
+    doc_edus = sorted([u for u in doc.units if is_edu(u)],
+                      key=lambda u: u.span)
+    # TODO doc_tstars = ...
+
+    src = anno.source
+    if is_cdu(src):
+        src_type = 'CDU'
+        src_edus = sorted(src.terminals(), key=lambda e: e.span)
+    elif is_edu(src):
+        src_type = 'EDU'
+        src_edus = [src]
+    else:
+        # covered by stac-check ("non-DU endpoints")
+        return {}
+
+    tgt = anno.target
+    if is_cdu(tgt):
+        tgt_type = 'CDU'
+        tgt_edus = sorted(tgt.terminals(), key=lambda e: e.span)
+    elif is_edu(tgt):
+        tgt_type = 'EDU'
+        tgt_edus = [tgt]
+    else:
+        # covered by stac-check ("non-DU endpoints")
+        return {}
+
+    # get the index of the EDUs in the interval between src and tgt
+    src_idc = [doc_edus.index(e) for e in src_edus]
+    tgt_idc = [doc_edus.index(e) for e in tgt_edus]
+
+    # error case covered at least partially by stac-check, either
+    # as "bizarre relation instance" or as "CDU punctures"
+    if set(src_idc).intersection(set(tgt_idc)):
+        if debug:
+            direction = 'messed up'
+            print('* {}: {} {}'.format(doc.origin, direction, anno.type))
+            print('\t' + ', '.join(['[{}] {}'.format(str(e.span),
+                                                     doc.text(e.span))
+                                    for e in src_edus]))
+            print('\t' + ', '.join(['[{}] {}'.format(str(e.span),
+                                                     doc.text(e.span))
+                                    for e in tgt_edus]))
+        return {}
+
+    # src ... tgt
+    if src_idc[-1] < tgt_idc[0]:
+        direction = 'right'
+        fst_idc = src_idc
+        snd_idc = tgt_idc
+        interv_edus = doc_edus[(fst_idc[-1] + 1):snd_idc[0]]
+    # tgt ... src
+    elif tgt_idc[-1] < src_idc[0]:
+        direction = 'left'
+        fst_idc = tgt_idc
+        snd_idc = src_idc
+        interv_edus = doc_edus[(fst_idc[-1] + 1):snd_idc[0]]
+    # tgt and src are interwoven
+    else:
+        direction = 'interwoven'  # FIXME
+        src_tgt_idc = set(src_idc).union(tgt_idc)
+        interv_edus = []
+        gap_edus = [e for i, e in enumerate(doc_edus)
+                    if (i not in src_tgt_idc and
+                        i > min(src_tgt_idc) and
+                        i < max(src_tgt_idc))]
+        if debug:
+            print('* {}: {} {}'.format(doc.origin, direction, anno.type))
+            print('\t' + ', '.join(['[{}] {}'.format(str(e.span),
+                                                     doc.text(e.span))
+                                    for e in src_edus]))
+            print('\t' + ', '.join(['[{}] {}'.format(str(e.span),
+                                                     doc.text(e.span))
+                                    for e in tgt_edus]))
+            print('\t' + ', '.join(['[{}] {}'.format(str(e.span),
+                                                     doc.text(e.span))
+                                    for e in gap_edus]))
+    edu_dist = len(interv_edus) + 1
+
+    # turn-stars distance
+    src_tstars = [ctx[e].tstar for e in src_edus]
+    tgt_tstars = [ctx[e].tstar for e in tgt_edus]
+    interv_tstars = [ctx[e].tstar for e in interv_edus]
+    # turn-stars from the interval that don't overlap with src nor tgt
+    skipped_tstars = set(interv_tstars) - set(src_tstars) - set(tgt_tstars)
+    # we define:
+    # * tstar_dist = 0  if (part of) src and tgt belong to the same tstar
+    # * tstar_dist = len(skipped_tstars) + 1 otherwise
+    tstar_dist = (len(skipped_tstars) + 1
+                  if not set(src_tstars).intersection(set(tgt_tstars))
+                  else 0)
+
+    res = {
+        'src_type': src_type,
+        'tgt_type': tgt_type,
+        'direction': direction,
+        'edu_dist': edu_dist,
+        'tstar_dist': tstar_dist,
+    }
+
+    return res
+
+
+def cdu_feats(anno):
+    """Get CDU features that are not immediate.
+
+    Returns
+    -------
+    nb_edus_tot: int
+        Total number of EDUs spanned by this CDU.
+
+    nb_cdus_imm: int
+        Number of CDUs immediately embedded in this CDU.
+
+    nb_cdus_tot: int
+        Total number of CDUs recursively embedded in this CDU.
+
+    max_lvl: int
+        Maximal degree of CDU nesting in this CDU.
+    """
+    nb_members = len(anno.members)
+    nb_cdus_imm = len([m for m in anno.members if is_cdu(m)])
+
+    nb_edus_tot = 0
+    nb_cdus_tot = 0
+    max_lvl = 0
+
+    cdus_to_expand = [(0, anno)]
+    while cdus_to_expand:
+        lvl, cur_cdu = cdus_to_expand.pop()
+        mem_lvl = lvl + 1
+        for member in cur_cdu.members:
+            if is_edu(member):
+                nb_edus_tot += 1
+            elif is_cdu(member):
+                nb_cdus_tot += 1
+                if mem_lvl > max_lvl:
+                    max_lvl = mem_lvl
+                cdus_to_expand.append((mem_lvl, member))
+            else:
+                raise ValueError('Unexpected type for a CDU member')
+
+    # TODO new features:
+    # * nb_gaps: CDUs spans can be discontiguous
+    # * gap_max_len: max len of a gap (in #EDUs)
+    # * over_nb_turns: nb of turns this CDU (partly) spans over
+    # * over_nb_tstars: nb of tstars this CDU (partly) spans over
+
+    res = {
+        'nb_members': nb_members,
+        'nb_cdus_imm': nb_cdus_imm,
+        'nb_cdus_tot': nb_cdus_tot,
+        'max_lvl': max_lvl,
+        'nb_edus_tot': nb_edus_tot,
+    }
+
+    return res
+
+
+def create_dfs(corpus):
+    """Create pandas DataFrames for the corpus.
+
+    Returns
+    -------
+    cdus:
+    rels:
+    """
+    cdu_data = []
+    rel_data = []
+    for file_id, doc in corpus.items():
+        # common stuff: get general info (doc, subdoc, annotator)
+        doc_name = file_id.doc
+        subdoc_name = file_id.subdoc
+        stage = file_id.stage
+        annotator = file_id.annotator
+        # context: yerk
+        ctx = Context.for_edus(doc)
+        #
+        for anno in doc.annotations():
+            common_cols = {
+                'anno_id': anno._anno_id,  # TODO get another way (hidden attribute)
+                'doc': doc_name,
+                'subdoc': subdoc_name,
+                'stage': stage,
+                'annotator': annotator,
+                'type': anno.type,  # ? maybe not
+            }
+            if is_cdu(anno):
+                row = dict(common_cols.items() +
+                           cdu_feats(anno).items())
+                cdu_data.append(row)
+            elif is_relation_instance(anno):
+                row = dict(common_cols.items() +
+                           rel_feats(doc, ctx, anno).items())
+                rel_data.append(row)
+    # create dataframes
+    cdus = pd.DataFrame(data=cdu_data)
+    rels = pd.DataFrame(data=rel_data)
+
+    return cdus, rels

--- a/educe/stac/util/cmd/pd_count.py
+++ b/educe/stac/util/cmd/pd_count.py
@@ -324,7 +324,11 @@ def create_dfs(corpus):
                 # 'Anaphora', 'Several_resources'
                 continue
             else:
-                raise ValueError('Unsupported annotation: {}'.format(anno))
+                err_msg = 'Unsupported annotation: {}'.format(anno)
+                # raise ValueError(err_msg)
+                print('W: {}'.format(err_msg))
+                continue
+
 
     res = {anno_type: pd.DataFrame(data=row_list)
            for anno_type, row_list in rows.items()

--- a/scripts/glozz
+++ b/scripts/glozz
@@ -8,59 +8,59 @@
 Swiss-army-knife for working with glozz files
 """
 import argparse
-import codecs
-import collections
 import copy
 import os
 import os.path
-import re
-import sys
-import textwrap
 import xml.etree.ElementTree as ET
 
-from   educe import glozz, corpus, stac, util, graph
-from   educe.annotation import Span, Unit
-from   educe.internalutil import linebreak_xml
+from educe.annotation import Span, Unit
+from educe.glozz import (read_annotation_file, write_annotation_file,
+                         DEFAULT_OUTPUT_SETTINGS, hashcode)
+from educe.internalutil import linebreak_xml
+from educe.stac import (stac_output_settings,
+                        stac_unannotated_output_settings)
 from educe.stac.util.annotate import schema_text
+
 
 # ---------------------------------------------------------------------
 # utility functions
 # ---------------------------------------------------------------------
-
 def nub(xs):
     """
     First occurrence of each list member
     """
     ys = []
     for x in xs:
-        if x not in ys: ys.append(x)
+        if x not in ys:
+            ys.append(x)
     return ys
 
+
 def seek_ac_file(aa_file):
-    fbase,fext = os.path.splitext(aa_file)
+    fbase, fext = os.path.splitext(aa_file)
     if fext is None:
         ac_file = None
     else:
         ac_file = fbase + ".ac"
     return ac_file
 
+
 # ---------------------------------------------------------------------
 # dump
 # ---------------------------------------------------------------------
-
 def dump(filename, doc):
-    show_unit = lambda u:\
-        "{anno} | {text}".format(anno=u,
-                                 text=doc.text(u.text_span()))
-    show_schema = lambda x:\
-        "{anno} | {text}".format(anno=x,
-                                 text=schema_text(doc, x))
-    lines = ['############### %s units' % filename]\
-          + list(map(show_unit, doc.units))\
-          + ['############### %s relations' % filename]\
-          + list(map(str, doc.relations))\
-          + ['############### %s schema' % filename]\
-          + list(map(show_schema, doc.schemas))
+    show_unit = (lambda u:
+                 "{anno} | {text}".format(anno=u,
+                                          text=doc.text(u.text_span())))
+    show_schema = (lambda x:
+                   "{anno} | {text}".format(anno=x,
+                                            text=schema_text(doc, x)))
+    lines = (['############### %s units' % filename] +
+             list(map(show_unit, doc.units)) +
+             ['############### %s relations' % filename] +
+             list(map(str, doc.relations)) +
+             ['############### %s schema' % filename] +
+             list(map(show_schema, doc.schemas)))
 
     return "\n".join(lines)
 
@@ -68,18 +68,17 @@ def dump(filename, doc):
 def main_dump(args):
     for file in args.files:
         ac_file = seek_ac_file(file)
-        doc = glozz.read_annotation_file(file,ac_file)
+        doc = read_annotation_file(file, ac_file)
         print dump(file, doc).encode('utf-8')
         print ""
+
 
 # ---------------------------------------------------------------------
 # shift
 # ---------------------------------------------------------------------
-
-
 def shift_glozz_file(file, start, offset):
     ac_file = seek_ac_file(file)
-    doc = glozz.read_annotation_file(file, ac_file)
+    doc = read_annotation_file(file, ac_file)
 
     def shift(x):
         if isinstance(x, Unit):
@@ -104,55 +103,61 @@ def shift_glozz_file(file, start, offset):
 
 def glozz_write_settings(args):
     if args.format == 'stac-unannotated':
-        return stac.stac_unannotated_output_settings
+        return stac_unannotated_output_settings
     elif args.format == 'stac':
-        return stac.stac_output_settings
+        return stac_output_settings
     else:
-        return glozz.default_output_settings
+        return DEFAULT_OUTPUT_SETTINGS
 
 
 def main_shift(args):
     settings = glozz_write_settings(args)
     doc = shift_glozz_file(args.input, args.start, args.shift)
-    glozz.write_annotation_file(args.output, doc, settings=settings)
+    write_annotation_file(args.output, doc, settings=settings)
+
 
 # ---------------------------------------------------------------------
 # cut
 # ---------------------------------------------------------------------
-
 def cut_glozz_file(file, span, offset=0):
     ac_file = seek_ac_file(file)
-    doc = glozz.read_annotation_file(file,ac_file)
+    doc = read_annotation_file(file, ac_file)
+
     def shift(x):
         if offset != 0 and isinstance(x, Unit):
-            x2      = copy.copy(x)
+            x2 = copy.copy(x)
             x2.span = x.span.shift(offset)
             return x2
         else:
             return x
+
     def slice(xs):
-        return [ shift(x) for x in xs if span.encloses(x.text_span()) ]
+        return [shift(x) for x in xs if span.encloses(x.text_span())]
+
     doc2 = copy.copy(doc)
-    doc2.units     = slice(doc.units)
-    doc2.schemas   = slice(doc.schemas)
+    doc2.units = slice(doc.units)
+    doc2.schemas = slice(doc.schemas)
     doc2.relations = slice(doc.relations)
     return doc2
 
+
 def glozz_write_settings(args):
     if args.format == 'stac-unannotated':
-        return stac.stac_unannotated_output_settings
+        return stac_unannotated_output_settings
     elif args.format == 'stac':
-        return stac.stac_output_settings
+        return stac_output_settings
     else:
-        return glozz.default_output_settings
+        return DEFAULT_OUTPUT_SETTINGS
+
 
 def main_cut(args):
     settings = glozz_write_settings(args)
     span = Span(args.start, args.end)
-    doc  = cut_glozz_file(args.input, span, args.shift)
-    glozz.write_annotation_file(args.output, doc, settings=settings)
+    doc = cut_glozz_file(args.input, span, args.shift)
+    write_annotation_file(args.output, doc, settings=settings)
     if args.shift is None:  # NB: not the same as 0!
         args.shift = 1 - args.start
+
 
 # ---------------------------------------------------------------------
 # normalise
@@ -161,20 +166,22 @@ def main_cut(args):
 # rather than passing through the educe glozz reading mechanisms.
 # I probably wanted something as functionally simple as possible
 # ---------------------------------------------------------------------
-
 class NormSettings(object):
     def __init__(self, mode, start):
-        self.mode  = mode
+        self.mode = mode
         self.start = start
+
 
 default_settings = NormSettings('count', 1)
 
+
 def mk_new_dates(dates, settings=default_settings):
-    start        = settings.start
+    start = settings.start
     unique_dates = nub(dates)
 
     if settings.mode == 'zero':
-        return { str(v):'0' for v in unique_dates    }
+        return {str(v): '0' for v in unique_dates}
+
     if settings.mode == 'negonly':
         # only normalise negative dates (in count mode)
         # this is kind of obscure, and only really makes sense in
@@ -182,32 +189,33 @@ def mk_new_dates(dates, settings=default_settings):
         # were given negative ids to distinguish them from others
         pos_dates = [x for x in unique_dates if x >= 0]
         neg_dates = [x for x in unique_dates if x < 0]
-        pos_dict = { str(v):str(v)  for v in pos_dates }
-        neg_dict = { str(v):str(-i) for i,v in enumerate(neg_dates, start) }
+        pos_dict = {str(v): str(v) for v in pos_dates}
+        neg_dict = {str(v): str(-i) for i, v in enumerate(neg_dates, start)}
         return dict(pos_dict.items() + neg_dict.items())
     else:
-        return { str(v):str(i) for i,v in enumerate(unique_dates, start) }
+        return {str(v): str(i) for i, v in enumerate(unique_dates, start)}
+
 
 def tidy(filename, output, mode=None):
-    tree    = ET.parse(filename)
+    tree = ET.parse(filename)
 
     date_elems = tree.findall('.//creation-date')
     unit_elems = tree.findall('.//*[@id]')
 
-    dates     = [ int(x.text.strip()) for x in date_elems ]
-    unit_ids  = [ x.attrib['id'] for x in unit_elems ]
+    dates = [int(x.text.strip()) for x in date_elems]
+    unit_ids = [x.attrib['id'] for x in unit_elems]
 
     new_dates = mk_new_dates(dates, mode)
 
     def adjust_id(x):
         xparts = x.rsplit('_', 1)
-        date2  = new_dates[xparts[-1]]
+        date2 = new_dates[xparts[-1]]
         return '_'.join(xparts[:-1] + [date2])
 
-    new_ids = { x:adjust_id(x) for x in unit_ids }
+    new_ids = {x: adjust_id(x) for x in unit_ids}
 
     for x in date_elems:
-        old    = str(x.text.strip())
+        old = str(x.text.strip())
         x.text = new_dates[old]
     for x in unit_elems:
         old = x.attrib['id']
@@ -216,41 +224,46 @@ def tidy(filename, output, mode=None):
     linebreak_xml(tree.getroot())
     tree.write(output, encoding='utf-8', xml_declaration=True)
 
+
 def main_normalise(args):
-    if not os.path.exists(args.output): os.mkdir(args.output)
+    if not os.path.exists(args.output):
+        os.mkdir(args.output)
     settings = NormSettings(args.mode, args.start)
     for f in args.input:
         f2 = os.path.join(args.output, os.path.basename(f))
         tidy(f, f2, settings)
 
+
 # ---------------------------------------------------------------------
 # hashcode
 # ---------------------------------------------------------------------
-
 def main_hashcode(args):
     with open(args.input, 'rb') as f:
-        print glozz.hashcode(f)
+        print hashcode(f)
+
 
 # ---------------------------------------------------------------------
 # args
 # ---------------------------------------------------------------------
-
 arg_parser = argparse.ArgumentParser(description='Glozz Swiss Army Knife')
 subparsers = arg_parser.add_subparsers(help='sub-command help')
 
-ap_dump = subparsers.add_parser('dump', help='Dump glozz file in an ad-hoc debug format')
+ap_dump = subparsers.add_parser('dump',
+                                help='Dump glozz file in an ad-hoc debug format')
 ap_dump.set_defaults(func=main_dump)
 ap_dump.add_argument('files', nargs='*')
 
-ap_cut = subparsers.add_parser('cut', help='Select a slice of glozz anotations from text span')
+ap_cut = subparsers.add_parser('cut',
+                               help='Select a slice of glozz anotations from text span')
 ap_cut.add_argument('input', metavar='FILE', help='Glozz aa file')
-ap_cut.add_argument('--format', choices=['default', 'stac', 'stac-unannotated'])
+ap_cut.add_argument('--format', choices=['default', 'stac',
+                                         'stac-unannotated'])
 ap_cut.add_argument('--shift', type=int, nargs='?',
                     default=0,
                     help='shift spans by this offset (default 0; unspecified:1-start)')
 ap_cut.add_argument('start', type=int,
                     help='Character offset of left of included window')
-ap_cut.add_argument( 'end', type=int,
+ap_cut.add_argument('end', type=int,
                     help='Character offset of right of included window')
 ap_cut.add_argument('output', metavar='FILE',
                     help='Output file')
@@ -258,7 +271,8 @@ ap_cut.set_defaults(func=main_cut)
 
 ap_shift = subparsers.add_parser('shift', help='Bump offsets in a glozz file')
 ap_shift.add_argument('input', metavar='FILE', help='Glozz aa file')
-ap_shift.add_argument('--format', choices=['default', 'stac', 'stac-unannotated'])
+ap_shift.add_argument('--format', choices=['default', 'stac',
+                                           'stac-unannotated'])
 ap_shift.add_argument('--shift', type=int, required=True,
                       help='shift spans by this offset')
 ap_shift.add_argument('start', type=int,
@@ -267,21 +281,23 @@ ap_shift.add_argument('output', metavar='FILE',
                       help='Output file')
 ap_shift.set_defaults(func=main_shift)
 
-ap_norm = subparsers.add_parser('normalise', help='Renumber Glozz ids/dates for comparability (use with care!)')
-ap_norm.add_argument('input', metavar='FILES', nargs = '+')
+ap_norm = subparsers.add_parser('normalise',
+                                help='Renumber Glozz ids/dates for comparability (use with care!)')
+ap_norm.add_argument('input', metavar='FILES', nargs='+')
 ap_norm.add_argument('--output', metavar='DIR',
                      action='store',
                      required=True,
                      help='Output directory')
-ap_norm.add_argument('--mode', choices=[ 'count', 'zero', 'negonly' ],
-                     help='Normalisation mode'
-                     )
-ap_norm.add_argument('--start', type=int, default=1, help='start indices from')
+ap_norm.add_argument('--mode', choices=['count', 'zero', 'negonly'],
+                     help='Normalisation mode')
+ap_norm.add_argument('--start', type=int, default=1,
+                     help='start indices from')
 ap_norm.add_argument('--verbose', '-v', action='store_true')
 ap_norm.set_defaults(func=main_normalise)
 
 
-ap_hashcode = subparsers.add_parser('hashcode', help='Print corpus hashcode for Glozz ac file')
+ap_hashcode = subparsers.add_parser('hashcode',
+                                    help='Print corpus hashcode for Glozz ac file')
 ap_hashcode.add_argument('input', metavar='FILE', help='Glozz ac file')
 ap_hashcode.set_defaults(func=main_hashcode)
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ REQS = [
     'tabulate',
     'nltk >= 3.0.0',
     'soundex',
-    'pandas >= 0.16',
+    'pandas >= 0.17',
 ]
 
 


### PR DESCRIPTION
This PR introduces a new, pandas-based, statistics module for the STAC corpus.

The new module provides the same statistics as its predecessor plus detailed statistics on CDUs and relations.

Additional enhancements:
* slightly better integration of turn-stars in the code base,
* various cosmetic changes (coding style).