### PR TITLE
[MRG+1] CDU distributive relations

### DIFF
--- a/educe/graph.py
+++ b/educe/graph.py
@@ -508,7 +508,7 @@ class Graph(gr.hypergraph, AttrsMixin):
         if deep:
             for m in list(members):
                 if self.is_cdu(m):
-                    members.update(self.cdu_members(m, True))
+                    members.update(self.cdu_members(m, deep=deep))
 
         return frozenset(members)
 

--- a/educe/graph.py
+++ b/educe/graph.py
@@ -502,16 +502,15 @@ class Graph(gr.hypergraph, AttrsMixin):
         that are members of (members of ..) this CDU.
         """
 
+        hyperedge = self.edgeform(cdu)
+        members = set(self.links(hyperedge))
+
         if deep:
-            members = set()
-            for m in self.cdu_members(cdu):
-                members.add(m)
+            for m in list(members):
                 if self.is_cdu(m):
-                    members.update(self.cdu_members(m,deep))
-            return frozenset(members)
-        else:
-            hyperedge = self.edgeform(cdu)
-            return frozenset(self.links(hyperedge))
+                    members.update(self.cdu_members(m, True))
+
+        return frozenset(members)
 
     def _mk_guid(self, x):
         return self.doc_key.mk_global_id(x)

--- a/educe/stac/graph.py
+++ b/educe/stac/graph.py
@@ -198,7 +198,7 @@ class Graph(educe.graph.Graph):
             src_node, tgt_node = links
 
             def candidates(node, distributive):
-                if self.is_edu(node):
+                if not self.is_cdu(node):
                     return [node]
                 if (mode != 'head' and
                     (mode == 'broadcast' or label in distributive)):
@@ -216,7 +216,7 @@ class Graph(educe.graph.Graph):
 
         def edu_components(node):
             """ Returns a list of all EDUs contained by a node. """
-            if self.is_edu(node):
+            if not self.is_cdu(node):
                 return [node]
             return [snode for snode in self.cdu_members(node, deep=True)
                         if self.is_edu(snode)]
@@ -239,6 +239,10 @@ class Graph(educe.graph.Graph):
             # Build a new edge for all new combinations
             for i, (n_src, n_tgt) in enumerate(
                 itertools.product(src_nodes, tgt_nodes)):
+                if n_src == n_tgt:
+                    print ("WARNING: something is pointing to its own CDU : "
+                        + str(n_src))
+                    continue
                 # First, build a new Relation for the annotation layer
                 n_src_anno = self.annotation(n_src)
                 n_tgt_anno = self.annotation(n_tgt)

--- a/educe/stac/graph.py
+++ b/educe/stac/graph.py
@@ -115,25 +115,19 @@ class Graph(educe.graph.Graph):
         A dictionary mapping each CDU to its recursive CDU
         head (see `cdu_head`)
         """
-        cache = {}
+        heads = {}
         def get_head(c):
-            if c in cache:
-                return cache[c]
-            else:
-                hd = self.cdu_head(c, sloppy)
-                if hd is None: return None
-                if self.is_cdu(hd):
-                    deep_hd = get_head(hd)
-                else:
-                    deep_hd = hd
-                if deep_hd is None:
-                    return None
-                else:
-                    cache[c] = deep_hd
-                    return deep_hd
+            if c in heads:
+                return heads[c]
+            hd = self.cdu_head(c, sloppy)
+            if (hd is not None) and self.is_cdu(hd):
+                hd = get_head(hd)
+            heads[c] = hd
+            return hd
+
         for c in self.cdus():
             get_head(c)
-        return cache
+        return heads
 
     def without_cdus(self, sloppy=False, mode='head'):
         """

--- a/educe/stac/graph.py
+++ b/educe/stac/graph.py
@@ -245,8 +245,8 @@ class Graph(educe.graph.Graph):
                     nodes = [heads[self.mirror(node)]]
                 return nodes
 
-            return [candidates(node, lset) for (node, lset) in
-                    ((src_node, LEFT_DIST), (tgt_node, RIGHT_DIST))]
+            return (candidates(src_node, LEFT_DIST),
+                    candidates(tgt_node, RIGHT_DIST))
 
         def edu_components(node):
             """ Returns a list of all EDUs contained by a node. """

--- a/educe/stac/graph.py
+++ b/educe/stac/graph.py
@@ -75,11 +75,7 @@ class Graph(educe.graph.Graph):
           and if sloppy is True, return the textually leftmost one;
           otherwise, raise a MultiheadedCduException
         """
-        if self.has_node(cdu):
-            hyperedge = self.mirror(cdu)
-        else:
-            hyperedge = cdu
-
+        hyperedge = self.edgeform(cdu)
         members = self.cdu_members(cdu)
         candidates = []
         # pylint seems confused by our use of inheritence
@@ -221,8 +217,8 @@ class Graph(educe.graph.Graph):
         and in case of a tie their inverse width (ie. widest first)
         """
         def is_interesting_du(n):
-            return self.is_edu(n) or\
-                (self.is_cdu(n) and self.cdu_members(n))
+            return (self.is_edu(n) or
+                (self.is_cdu(n) and self.cdu_members(n)))
 
         dus = list(filter(is_interesting_du,self.nodes()))
         return self.sorted_first_outermost(dus)

--- a/educe/stac/learning/cmd/extract.py
+++ b/educe/stac/learning/cmd/extract.py
@@ -71,6 +71,10 @@ def config_argparser(parser):
                         help='Vocabulary file (for --parsing mode)')
     parser.add_argument('--ignore-cdus', action='store_true',
                         help='Avoid going into CDUs')
+    parser.add_argument('--strip-mode',
+                        choices=['head', 'broadcast', 'custom'],
+                        default='head',
+                        help='CDUs stripping method (if going into CDUs)')
     parser.set_defaults(func=main)
 
 # ---------------------------------------------------------------------

--- a/educe/stac/learning/features.py
+++ b/educe/stac/learning/features.py
@@ -133,15 +133,14 @@ INQUIRER_CLASSES = ['Positiv',
 # ---------------------------------------------------------------------
 # preprocessing
 # ---------------------------------------------------------------------
-def strip_cdus(corpus):
+def strip_cdus(corpus, mode):
     """
     For all documents in a corpus, remove any CDUs and relink the
-    document accordingly.  This mutates the corpus
+    document according to the desired mode. This mutates the corpus.
     """
     for key in corpus:
-        # replace all CDUs in links with their recursive heads
         graph = stac_gr.Graph.from_doc(corpus, key)
-        graph.strip_cdus(sloppy=True)
+        graph.strip_cdus(sloppy=True, mode=mode)
 
 # ---------------------------------------------------------------------
 # relation queries
@@ -1427,7 +1426,7 @@ def read_corpus_inputs(args):
     corpus = reader.slurp(anno_files, verbose=True)
 
     if not args.ignore_cdus:
-        strip_cdus(corpus)
+        strip_cdus(corpus, mode=args.strip_mode)
     postags = postag.read_tags(corpus, args.corpus)
     parses = corenlp.read_results(corpus, args.corpus)
     _fuse_corpus(corpus, postags)

--- a/educe/stac/util/cmd/graph.py
+++ b/educe/stac/util/cmd/graph.py
@@ -178,7 +178,8 @@ def config_argparser(parser):
                          help='Separate file for each connected component')
     psr_rel.add_argument('--strip-cdus', action='store_true',
                          help='Strip away CDUs')
-    psr_rel.add_argument('--strip-mode', choices=['head', 'broadcast'],
+    psr_rel.add_argument('--strip-mode',
+                         choices=['head', 'broadcast', 'custom'],
                          default='head',
                          help='CDUs stripping method')
 

--- a/educe/stac/util/cmd/graph.py
+++ b/educe/stac/util/cmd/graph.py
@@ -59,7 +59,7 @@ def _main_rel_graph(args):
         try:
             gra = stacgraph.Graph.from_doc(corpus, k)
             if args.strip_cdus:
-                gra = gra.without_cdus()
+                gra = gra.without_cdus(mode=args.strip_mode)
             dot_gra = stacgraph.DotGraph(gra)
             if dot_gra.get_nodes():
                 write_dot_graph(k, output_dir, dot_gra,
@@ -177,7 +177,10 @@ def config_argparser(parser):
     psr_rel.add_argument('--split', action='store_true',
                          help='Separate file for each connected component')
     psr_rel.add_argument('--strip-cdus', action='store_true',
-                         help='Strip away CDUs (substitute w heads)')
+                         help='Strip away CDUs')
+    psr_rel.add_argument('--strip-mode', choices=['head', 'broadcast'],
+                         default='head',
+                         help='CDUs stripping method')
 
     psr_rfc = parser.add_argument_group("RFC graphs")
     psr_rfc.add_argument('--rfc', choices=['basic', 'mlast'],


### PR DESCRIPTION
This PR adds a new way to strip CDUs from a graph.

So far relation sources/targets are relocated to the recursive head of the CDUs when stripping. The new modes trigger distribution over all components of the CDUs, always (for `broadcast` mode) or depending on the label (`custom` mode). The process creates new edges.

I'm working on attelo integration of the process, and I will probably add new commits.