### PR TITLE
[MRG] RST corpus diagnostics: leaky sentences

### DIFF
--- a/educe/rst_dt/annotation.py
+++ b/educe/rst_dt/annotation.py
@@ -437,7 +437,7 @@ def _chain_to_binary(rel, kids):
         edu_span = (lnode.edu_span[0], rnode.edu_span[1])
         span = lnode.span.merge(rnode.span)
         newnode = Node('Nucleus', edu_span, span, rel)
-        return RSTTree(newnode, [left, right])
+        return RSTTree(newnode, [left, right], origin=left.origin)
     return functools.reduce(builder, kids[::-1])
 
 
@@ -479,7 +479,8 @@ def _binarize(tree):
         raise RSTTreeException("Ill-formed RST tree? Unary non-terminal: " +
                                str(tree))
     elif len(tree) <= 2:
-        return RSTTree(treenode(tree), list(map(_binarize, tree)))
+        return RSTTree(treenode(tree), list(map(_binarize, tree)),
+                       origin=tree.origin)
     else:
         # convenient string representation of what the children look like
         # eg. NS, SN, NNNNN, SNS
@@ -499,10 +500,10 @@ def _binarize(tree):
             kids = [_binarize(x) for x in tree]
             left = kids[0]
             right = _chain_to_binary(treenode(left).rel, kids[1:])
-            return RSTTree(treenode(tree), [left, right])
+            return RSTTree(treenode(tree), [left, right], origin=tree.origin)
         elif nscode == 'SNS':
             left = _chain_to_binary('span', tree[:2])
             right = _binarize(tree[2])
-            return RSTTree(treenode(tree), [left, right])
+            return RSTTree(treenode(tree), [left, right], origin=tree.origin)
         else:
             raise RSTTreeException("Don't know how to handle %s trees", nscode)

--- a/educe/rst_dt/corpus_diagnostics.py
+++ b/educe/rst_dt/corpus_diagnostics.py
@@ -4,7 +4,7 @@
 
 from __future__ import print_function
 
-from collections import Counter, defaultdict
+from collections import Counter
 import os
 
 import pandas as pd
@@ -240,12 +240,13 @@ def parse_doc_ptb(doc_id, doc_tkd_toks):
         # ("tree position" in NLTK) in the tree
         lheads = find_lexical_heads(clean_tree)
         lex_heads.append(lheads)
-    return trees  #, lex_heads
+    return trees  # , lex_heads
 
 
 # WIP straddling relations ; definitely dirty as is
 strad_rels_rows = []
 # end WIP straddling relations
+
 
 # clean stuff
 def load_edus(doc_edus):
@@ -354,7 +355,6 @@ def load_spans(coarse_rtree_ref):
     return doc_span_rows
 
 
-@profile
 def load_training_as_dataframe_new(binarize=False):
     """Load training section of the RST-WSJ corpus as a pandas.DataFrame.
 
@@ -517,8 +517,8 @@ def load_training_as_dataframe_new(binarize=False):
                     strad_spans = []
                     for edu_span in rst_tree_node_spans_by_len:
                         # parent span
-                        if (edu_span[0] <= sent_edu_first and
-                            sent_edu_last <= edu_span[1]):
+                        if ((edu_span[0] <= sent_edu_first and
+                             sent_edu_last <= edu_span[1])):
                             parent_span = edu_span
                             break
                         # straddling spans
@@ -537,7 +537,7 @@ def load_training_as_dataframe_new(binarize=False):
                     # outside the sentence ;
                     # no member straddles either of the sentence
                     # boundaries
-                    leaky_type_12 = not(strad_spans)
+                    leaky_type_12 = not strad_spans
                     # DEBUG
                     print(doc_id.doc)
                     print(parent_span, strad_spans if strad_spans else '')
@@ -581,7 +581,8 @@ def load_training_as_dataframe_new(binarize=False):
                             'node_id': '{}_const{}'.format(
                                 strad_subtree.origin.doc,
                                 '-'.join(str(x) for x in strad_tpos)),
-                            'sent_id': '{}_sent{}'.format(doc_id.doc, sent_idx),
+                            'sent_id': '{}_sent{}'.format(
+                                doc_id.doc, sent_idx),
                             'kid_rels': kid_rels,
                         })
                         # end WIP running counter
@@ -648,7 +649,7 @@ def load_training_as_dataframe_new(binarize=False):
             edu2para = align_edus_with_paragraphs(doc_edus, doc_paras,
                                                   doc_text, strict=False)
             edu2para_codom = set([para_idx for para_idx in edu2para
-                                 if para_idx is not None])
+                                  if para_idx is not None])
             # index of the first and last EDU of each paragraph
             para_edu_starts = [(edu2para.index(i) + 1 if i in edu2para_codom
                                 else None)
@@ -691,12 +692,12 @@ def load_training_as_dataframe_new(binarize=False):
                         })
                     else:
                         row.update({'leaky': False})
-                    # WIP find for each leaky paragraph the smallest RST subtree
-                    # that covers it
+                    # WIP find for each leaky paragraph the smallest RST
+                    # subtree that covers it
                     if row['leaky']:
                         for edu_span in rst_tree_node_spans_by_len:
-                            if (edu_span[0] <= para_edu_starts[para_idx] and
-                                para_edu_ends[para_idx] <= edu_span[1]):
+                            if ((edu_span[0] <= para_edu_starts[para_idx] and
+                                 para_edu_ends[para_idx] <= edu_span[1])):
                                 parent_span = edu_span
                                 break
                         else:
@@ -711,9 +712,9 @@ def load_training_as_dataframe_new(binarize=False):
                             'parent_para_len': (
                                 edu2para[parent_span[1] - 1] -
                                 edu2para[parent_span[0] - 1] + 1),
-                            # distance between the current paragraph and the most
-                            # remote paragraph covered by the parent span, in
-                            # paragraphs
+                            # distance between the current paragraph and the
+                            # most remote paragraph covered by the parent
+                            # span, in paragraphs
                             'parent_para_dist': (
                                 max([(edu2para[parent_span[1] - 1] - para_idx),
                                      (para_idx - edu2para[parent_span[0] - 1])])),

--- a/educe/rst_dt/corpus_diagnostics.py
+++ b/educe/rst_dt/corpus_diagnostics.py
@@ -4,7 +4,7 @@
 
 from __future__ import print_function
 
-from collections import Counter
+from collections import Counter, defaultdict
 import os
 
 import pandas as pd
@@ -14,14 +14,29 @@ from educe.rst_dt.annotation import RSTTree
 from educe.rst_dt.corpus import (Reader as RstReader,
                                  RstRelationConverter,
                                  RELMAP_112_18_FILE)
+# imports for dirty stuff (mostly)
+import itertools
+
+from nltk.corpus.reader import BracketParseCorpusReader
+
+from educe.annotation import Span
+from educe.external.parser import ConstituencyTree
+from educe.internalutil import izip
+from educe.rst_dt.ptb import (_guess_ptb_name, _tweak_token,
+                              is_empty_category, generic_token_spans,
+                              _mk_token, align_edus_with_sentences)
+from educe.ptb.annotation import (prune_tree, is_non_empty, transform_tree,
+                                  strip_subcategory)
+from educe.ptb.head_finder import find_lexical_heads
+# end imports for dirty stuff
 
 
 # RST corpus
 # TODO import CORPUS_DIR/CD_TRAIN e.g. from educe.rst_dt.rst_wsj_corpus
 CORPUS_DIR = os.path.join(os.path.dirname(__file__),
-                          '..', '..',
-                          'data/rst_discourse_treebank/data',
-                          'RSTtrees-WSJ-main-1.0/')
+                          '..', '..', '..', '..', 'corpora',
+                          'rst_discourse_treebank', 'data',
+                          'RSTtrees-WSJ-main-1.0')
 CD_TRAIN = os.path.join(CORPUS_DIR, 'TRAINING')
 # relation converter (fine- to coarse-grained labels)
 REL_CONV = RstRelationConverter(RELMAP_112_18_FILE).convert_tree
@@ -77,6 +92,7 @@ def load_training_as_dataframe():
             #
 
             rst_phrases.append(res)
+
     # turn into a DataFrame
     df = pd.DataFrame(rst_phrases)
     # add calculated columns
@@ -156,3 +172,334 @@ def check_label_ranks():
                     in sorted(Counter(labels_ranks_gold).items())))
     print('labels inc. nuc and rank :', len(Counter(labels_ranks_gold)))
     print('\n\n\n')
+
+
+# WIP
+# dirty, almost copies from educe.rst_dt.ptb.PtbParser...
+# TODO go and fix educe.rst_dt.{ptb, corenlp}
+PTB_DIR = os.path.join(os.path.dirname(__file__),
+                       '..', '..', '..', '..', 'corpora',
+                       'PTBIII', 'parsed', 'mrg', 'wsj')
+PTB_READER = BracketParseCorpusReader(PTB_DIR,
+                                      r'../wsj_.*\.mrg',
+                                      encoding='ascii')
+
+
+def tokenize_doc_ptb(doc_id, doc_text):
+    """Dirty PTB tokenizer"""
+    ptb_name = _guess_ptb_name(doc_id)
+    if ptb_name is None:
+        return None
+
+    # get doc text
+    # here we cheat and get it from the RST-DT tree
+    # was: rst_text = doc.orig_rsttree.text()
+    rst_text = doc_text
+    tagged_tokens = PTB_READER.tagged_words(ptb_name)
+    # tweak tokens THEN filter empty nodes
+    tweaked1, tweaked2 =\
+        itertools.tee(_tweak_token(ptb_name)(i, tok) for i, tok in
+                      enumerate(tagged_tokens)
+                      if not is_empty_category(tok[1]))
+    spans = generic_token_spans(rst_text, tweaked1,
+                                txtfn=lambda x: x.tweaked_word)
+    result = [_mk_token(t, s) for t, s in izip(tweaked2, spans)]
+    return result
+
+
+def parse_doc_ptb(doc_id, doc_tkd_toks):
+    """Dirty PTB parser"""
+    # get PTB trees
+    ptb_name = _guess_ptb_name(doc_id)
+    if ptb_name is None:
+        return None
+
+    # use tweaked tokens
+    doc_tokens = doc_tkd_toks
+    tokens_iter = iter(doc_tokens)
+
+    trees = []
+    lex_heads = []
+    for tree in PTB_READER.parsed_sents(ptb_name):
+        # apply standard cleaning to tree
+        # strip function tags, remove empty nodes
+        tree_no_empty = prune_tree(tree, is_non_empty)
+        tree_no_empty_no_gf = transform_tree(tree_no_empty,
+                                             strip_subcategory)
+        #
+        leaves = tree_no_empty_no_gf.leaves()
+        tslice = itertools.islice(tokens_iter, len(leaves))
+        clean_tree = ConstituencyTree.build(tree_no_empty_no_gf,
+                                            tslice)
+        trees.append(clean_tree)
+
+        # lexicalize the PTB tree: find the head word of each constituent
+        # constituents and their heads are designated by their Gorn address
+        # ("tree position" in NLTK) in the tree
+        lheads = find_lexical_heads(clean_tree)
+        lex_heads.append(lheads)
+    return trees  #, lex_heads
+
+
+# clean stuff
+def load_training_as_dataframe_new():
+    """Load training section of the RST-WSJ corpus as a pandas.DataFrame.
+
+    Returns
+    -------
+    node_df: pandas.DataFrame
+        DataFrame of all nodes from the constituency trees.
+    rel_df: pandas.DataFrame
+        DataFrame of all relations.
+    edu_df: pandas.DataFrame
+        DataFrame of all EDUs.
+    """
+    node_rows = []  # list of dicts, one dict per node
+    rel_rows = []  # list of dicts, one dict per relation
+    # edu_rows contains pre-EDUs rather than EDUs themselves, but maybe
+    # conflating both does no harm
+    edu_rows = []  # list of dicts, one dict per EDU
+    sent_rows = []  # ibid
+    # TODO para_rows, look at leaky paragraphs (if they exist)
+
+    rst_reader = RstReader(CD_TRAIN)
+    rst_corpus = rst_reader.slurp()
+
+    for doc_id, rtree_ref in sorted(rst_corpus.items()):
+        doc_text = rtree_ref.label().context.text()
+        doc_edus = rtree_ref.leaves()
+
+        # 1. Collect constituency nodes and EDUs from the gold RST trees
+        doc_rst_rel_rows = []
+        doc_edu_rows = []
+
+        # convert labels to coarse
+        coarse_rtree_ref = REL_CONV(rtree_ref)
+
+        # RST nodes: constituents are either relations or EDUs
+        for node_idx, node in enumerate(coarse_rtree_ref.subtrees()):
+            node_label = node.label()
+            node_id = '{}_const{}'.format(node.origin.doc, node_idx)
+            # node
+            row = {
+                'node_id': node_id,
+                # char span
+                'span_start': node_label.span.char_start,
+                'span_end': node_label.span.char_end,
+                # nuclearity
+                'nuclearity': node_label.nuclearity,
+                # relation
+                'relation': node_label.rel,
+            }
+
+            if len(node) > 1:  # internal node => relation
+                row.update({
+                    # edu span
+                    'edu_span_start': node_label.edu_span[0],
+                    'edu_span_end': node_label.edu_span[1],
+                    # info on children
+                    'arity': len(node),
+                    'kids_rel': '+'.join(
+                        set(kid.label().rel for kid in node
+                            if kid.label().rel != 'span')),
+                    'kids_nuc': ''.join(
+                        ('N' if kid.label().nuclearity == 'Nucleus' else 'S')
+                        for kid in node),
+                })
+                # TODO add a column for sentential status (intra or inter)
+                # (once we have the sentences and EDU <-> sentence mapping)
+                doc_rst_rel_rows.append(row)
+            else:  # pre-EDU
+                edu = node[0]
+                row.update({
+                    'num': edu.num,
+                })
+                doc_edu_rows.append(row)
+
+        # 2. Collect sentences
+        doc_sent_rows = []
+        # use dirty PTB tokenizer + parser
+        doc_tkd_toks = tokenize_doc_ptb(doc_id, doc_text)
+        doc_tkd_trees = parse_doc_ptb(doc_id, doc_tkd_toks)
+
+        # sentence <-> EDU mapping and the information that depends on this
+        # mapping might be more appropriate as a separate DataFrame
+        # align EDUs with sentences
+        edu2sent = align_edus_with_sentences(doc_edus, doc_tkd_trees,
+                                             strict=False)
+        # get the codomain of edu2sent
+        # if we want to be strict, we can assert that the codomain is
+        # a gapless interval
+        # assert sent_idc == list(range(len(doc_tkd_trees)))
+        # this assertion is currently known to fail on:
+        # * RST-WSJ/TRAINING/wsj_0678.out: wrong sentence segmentation in PTB
+        #     (1 sentence is split in 2)
+        edu2sent_codom = set([sent_idx for sent_idx in edu2sent
+                              if sent_idx is not None])
+
+        # find the index of the first and last EDU of each sentence
+        # indices in both lists are offset by 1 to map to real EDU
+        # numbering (which is 1-based)
+        sent_edu_starts = [(edu2sent.index(i) + 1 if i in edu2sent_codom
+                            else None)
+                           for i in range(len(doc_tkd_trees))]
+        sent_edu_ends = [(len(edu2sent) - 1 - edu2sent[::-1].index(i) + 1
+                          if i in edu2sent_codom
+                          else None)
+                         for i in range(len(doc_tkd_trees))]
+        # sentences with 2+ EDUs are 'complex'
+        # TODO rewrite with numpy.unique
+        complex_sent_idc = set(sent_idx for sent_idx, nb_occs
+                               in Counter(edu2sent).items()
+                               if nb_occs > 1 and sent_idx is not None)
+        # sentences that don't have their own RST subtree are 'leaky' ;
+        # collect the EDU spans of all constituent nodes from the RST tree
+        rst_tree_node_spans = set((row['edu_span_start'], row['edu_span_end'])
+                                  for row in doc_rst_rel_rows)
+        # WIP
+        rst_tree_node_spans_by_len = defaultdict(list)
+        for edu_span in rst_tree_node_spans:
+            edu_span_len = edu_span[1] - edu_span[0]
+            rst_tree_node_spans_by_len[edu_span_len].append(edu_span)
+        # end WIP
+        # end of sentence <-> EDU mapping et al.
+
+        # iterate over syntactic trees as proxy for sentences
+        for sent_idx, tkd_tree in enumerate(doc_tkd_trees):
+            row = {
+                # data directly from the sentence segmenter
+                'sent_id': '{}_sent{}'.format(doc_id.doc, sent_idx),
+                'span_start': tkd_tree.span.char_start,
+                'span_end': tkd_tree.span.char_end,
+            }
+            # sentence <-> EDU mapping dependent data
+            # should probably have its own dataframe
+            # to better handle disagreement between sentence and EDU
+            # segmentation, that translates in the following entries
+            # as None for missing data
+            if sent_idx in edu2sent_codom:
+                row.update({
+                    'edu_span_start': sent_edu_starts[sent_idx],
+                    'edu_span_end': sent_edu_ends[sent_idx],
+                    # computed column
+                    'edu_span_len': (sent_edu_ends[sent_idx] -
+                                     sent_edu_starts[sent_idx]) + 1,
+                    # TODO add columns using pandas
+                    # or: sent_edu_starts[sent_idx] != sent_edu_ends[sent_idx]
+                    'complex': (sent_idx in complex_sent_idc),
+                    'leaky': (sent_idx in complex_sent_idc and
+                              ((sent_edu_starts[sent_idx],
+                                sent_edu_ends[sent_idx])
+                               not in rst_tree_node_spans)),
+                })
+                # WIP
+                # WIP find for each leaky sentence the smallest RST subtree
+                # that covers it
+                if row['leaky']:
+                    for edu_span in itertools.chain.from_iterable(
+                            [edu_spans for span_len, edu_spans
+                             in sorted(
+                                 rst_tree_node_spans_by_len.items())]):
+                        if (edu_span[0] <= sent_edu_starts[sent_idx] and
+                            sent_edu_ends[sent_idx] <= edu_span[1]):
+                            parent_span = edu_span
+                            break
+                    else:
+                        raise ValueError(
+                            'No minimal spanning node for {}'.format(row))
+                    # add info to row
+                    try:
+                        row.update({
+                            # parent span, on EDUs
+                            'parent_span_start': parent_span[0],
+                            'parent_span_end': parent_span[1],
+                            # length of parent span, in sentences
+                            'parent_span_sent_len': (
+                                edu2sent[parent_span[1] - 1] -
+                                edu2sent[parent_span[0] - 1] + 1),
+                        })
+                    except TypeError:
+                        print(doc_id.doc)
+                        print(row['edu_span_start'], row['edu_span_end'])
+                        print(parent_span)
+                        raise
+                    sent_span = Span(row['span_start'], row['span_end'])
+                    print('{}: Leaky sentence [{}-{}] in [{}-{}]'.format(
+                        doc_id, row['edu_span_start'], row['edu_span_end'],
+                        row['parent_span_start'], row['parent_span_end']))
+                    print(rtree_ref.label().context.text(sent_span))
+                    print('Parent span covers {} sentences'.format(
+                        row['parent_span_sent_len']))
+                    print()
+                else:
+                    row.update({
+                        'parent_span_start': row['edu_span_start'],
+                        'parent_span_end': row['edu_span_end'],
+                    })
+                # end WIP
+            doc_sent_rows.append(row)
+        # NB: these are leaky sentences wrt the original constituency
+        # trees ; leaky sentences wrt the binarized constituency trees
+        # might be different (TODO), similarly for the dependency trees
+        # (TODO too) ;
+        # I should count them, see if the ~5% Joty mentions are on the
+        # original or binarized ctrees, and compare with the number of
+        # leaky for deptrees ; I suspect the latter will be much lower...
+        # HYPOTHESIS: (some or all?) leaky sentences in ctrees correspond
+        # to cases where nodes that are not the head of their sentence
+        # have dependents in other sentences
+        # this would capture the set (or a subset) of edges that fall
+        # outside of the search space for the "iheads" intra/inter
+        # strategy
+
+        # add doc entries to corpus entries
+        sent_rows.extend(doc_sent_rows)
+        rel_rows.extend(doc_rst_rel_rows)
+        edu_rows.extend(doc_edu_rows)
+
+    # turn list into a DataFrame
+    node_df = pd.DataFrame(node_rows)
+    rel_df = pd.DataFrame(rel_rows)
+    edu_df = pd.DataFrame(edu_rows)
+    sent_df = pd.DataFrame(sent_rows)
+    # add calculated columns here? (leaky and complex sentences)
+
+    return node_df, rel_df, edu_df, sent_df
+
+
+nodes_train, rels_train, edus_train, sents_train = load_training_as_dataframe_new()
+# print(rels_train)
+# as of version 0.17, pandas handles missing boolean values by degrading
+# column type to object, which makes boolean selection return true for
+# all non-None values ; the best workaround is to explicitly fill boolean
+# na values
+sents_train = sents_train.fillna(value={'complex': False, 'leaky': False})
+# exclude 'fileX' documents
+if False:
+    sents_train = sents_train[~sents_train['sent_id'].str.startswith('file')]
+
+# proportion of leaky sentences
+leaky_sents = sents_train[sents_train.leaky]
+# according to (Soricut and Marcu, 2003), p. 2, should be 323/6132 = 5.3%
+print('Leaky: {} / {} = {}'.format(
+    len(leaky_sents), len(sents_train),
+    float(len(leaky_sents)) / len(sents_train)))
+complex_sents = sents_train[sents_train.complex]
+print('Complex: {} / {} = {}'.format(
+    len(complex_sents), len(sents_train),
+    float(len(complex_sents)) / len(sents_train)))
+# assert there is no sentence which is leaky but not complex
+assert sents_train[sents_train.leaky & (~sents_train.complex)].empty
+# proportion of complex sentences that are leaky
+print('Leaky | Complex: {} / {} = {}'.format(
+    len(leaky_sents), len(complex_sents),
+    float(len(leaky_sents)) / len(complex_sents)))
+# compare leaky sentences with all complex sentences: length
+print(complex_sents['edu_span_len'].describe())
+print(leaky_sents['edu_span_len'].describe())
+print(leaky_sents['parent_span_sent_len'].describe())
+print(leaky_sents['parent_span_sent_len'].value_counts())
+# WEIRDOS
+# constituent nodes whose kids bear different relations
+print([kid_rel for kid_rel in rels_train['kids_rel']
+       if '+' in kid_rel])

--- a/educe/rst_dt/corpus_diagnostics.py
+++ b/educe/rst_dt/corpus_diagnostics.py
@@ -181,7 +181,8 @@ def check_label_ranks():
 # dirty, almost copies from educe.rst_dt.ptb.PtbParser...
 # TODO go and fix educe.rst_dt.{ptb, corenlp}
 PTB_DIR = os.path.join(os.path.dirname(__file__),
-                       '..', '..', '..', '..', 'corpora',
+                       '..', '..',
+                       'data',  # alt: '..', '..', 'corpora',
                        'PTBIII', 'parsed', 'mrg', 'wsj')
 PTB_READER = BracketParseCorpusReader(PTB_DIR,
                                       r'../wsj_.*\.mrg',

--- a/educe/rst_dt/corpus_diagnostics.py
+++ b/educe/rst_dt/corpus_diagnostics.py
@@ -36,7 +36,8 @@ from educe.ptb.head_finder import find_lexical_heads
 # RST corpus
 # TODO import CORPUS_DIR/CD_TRAIN e.g. from educe.rst_dt.rst_wsj_corpus
 CORPUS_DIR = os.path.join(os.path.dirname(__file__),
-                          '..', '..', '..', '..', 'corpora',
+                          '..', '..',
+                          'data',  # alt: '..', '..', 'corpora',
                           'rst_discourse_treebank', 'data',
                           'RSTtrees-WSJ-main-1.0')
 CD_TRAIN = os.path.join(CORPUS_DIR, 'TRAINING')

--- a/educe/rst_dt/corpus_diagnostics.py
+++ b/educe/rst_dt/corpus_diagnostics.py
@@ -320,6 +320,7 @@ def load_spans(coarse_rtree_ref):
                 '-'.join(str(x) for x in parent_tpos))
         else:  # missing value, for the root node
             parent_id = None
+        # update (proto) dataframe entry
         row.update({
             'parent_id': parent_id,
         })
@@ -338,10 +339,9 @@ def load_spans(coarse_rtree_ref):
             kid_nucs = ''.join(('N' if kid.label().nuclearity == 'Nucleus'
                                 else 'S')
                                for kid in node)
-        else:  # pre-terminals (pre-EDUs)
+        else:  # missing values, for pre-terminals (pre-EDUs)
             kid_rels = None
             kid_nucs = None
-
         # update (proto) dataframe entry
         row.update({
             'kid_rels': kid_rels,
@@ -391,16 +391,19 @@ def load_training_as_dataframe_new(binarize=False):
         doc_text = doc_ctx.text()
         doc_edus = rtree_ref.leaves()
 
-        # convert labels to coarse
+        # 0. collect EDUs
+        doc_edu_rows = load_edus(doc_edus)
+
+        # 1. collect spans (constituency nodes) from the gold RST trees
+        #
+        # transform the original RST tree: convert labels to their
+        # coarse equivalent, binarize if required
         coarse_rtree_ref = REL_CONV(rtree_ref)
-        # binarize if necessary
         if binarize:
             coarse_rtree_ref = _binarize(coarse_rtree_ref)
-
-        # 1. Collect constituency nodes and EDUs from the gold RST trees
-        edus = coarse_rtree_ref.leaves()
-        doc_edu_rows = load_edus(edus)
+        # collect spans
         doc_span_rows = load_spans(coarse_rtree_ref)
+
         # prepare this info to find "leaky" substructures:
         # sentences and paragraphs
         # dict of EDU spans to constituent node from the RST tree
@@ -445,6 +448,28 @@ def load_training_as_dataframe_new(binarize=False):
                           else None)
                          for i in range(len(doc_tkd_trees))]
         # sentences that don't have their own RST subtree are 'leaky'
+
+        # WIP propagate sentence-EDU mapping to RST tree spans
+        for row in doc_span_rows:
+            # offset by -1 because edu2sent is 0-based
+            row['sent_start'] = edu2sent[row['edu_start'] - 1]
+            row['sent_end'] = edu2sent[row['edu_end'] - 1]
+            # inferred columns
+            # special cases because edu2sent is None for EDUs whose text
+            # is missing from PTB
+            if ((row['sent_start'] is not None and
+                 row['sent_end'] is not None)):
+                row['sent_len'] = row['sent_end'] - row['sent_start'] + 1
+                row['intra_sent'] = (row['sent_start'] == row['sent_end'])
+                row['strad_sent'] = (not row['intra_sent'] and
+                                     (row['edu_start'] in sent_edu_starts and
+                                      row['edu_end'] in sent_edu_ends))
+            else:
+                row['sent_len'] = None
+                row['intra_sent'] = None
+                row['strad_sent'] = None
+        # end WIP propagate
+
         # end of sentence <-> EDU mapping et al.
 
         # iterate over syntactic trees as proxy for sentences
@@ -452,8 +477,8 @@ def load_training_as_dataframe_new(binarize=False):
             row = {
                 # data directly from the sentence segmenter
                 'sent_id': '{}_sent{}'.format(doc_id.doc, sent_idx),
-                'span_start': tkd_tree.span.char_start,
-                'span_end': tkd_tree.span.char_end,
+                'char_start': tkd_tree.span.char_start,
+                'char_end': tkd_tree.span.char_end,
             }
             # sentence <-> EDU mapping dependent data
             # should probably have its own dataframe
@@ -462,21 +487,23 @@ def load_training_as_dataframe_new(binarize=False):
             # as None for missing data
             if sent_idx in edu2sent_codom:
                 row.update({
-                    'edu_span_start': sent_edu_starts[sent_idx],
-                    'edu_span_end': sent_edu_ends[sent_idx],
+                    'edu_start': sent_edu_starts[sent_idx],
+                    'edu_end': sent_edu_ends[sent_idx],
                     # computed column
-                    'edu_span_len': (sent_edu_ends[sent_idx] -
-                                     sent_edu_starts[sent_idx]) + 1,
+                    'edu_len': (sent_edu_ends[sent_idx] -
+                                sent_edu_starts[sent_idx]) + 1,
                 })
-                # use sentence <-> RST tree alignment
-                if row['edu_span_len'] > 1:
-                    row.update({
-                        'leaky': ((sent_edu_starts[sent_idx],
-                                   sent_edu_ends[sent_idx])
-                                  not in rst_tree_node_spans),
-                    })
-                else:
-                    row.update({'leaky': False})
+
+                # use alignment: sentence <-> RST tree spans (via EDUs)
+                # leaky sentences: complex (2+ EDUs) sentences that don't
+                # have a corresponding span in the RST tree
+                leaky = (row['edu_len'] > 1 and
+                         ((sent_edu_starts[sent_idx],
+                           sent_edu_ends[sent_idx])
+                          not in rst_tree_node_spans))
+                row.update({
+                    'leaky': leaky,
+                })
                 # find for each leaky sentence the smallest RST subtree
                 # that covers it
                 if row['leaky']:
@@ -553,7 +580,7 @@ def load_training_as_dataframe_new(binarize=False):
                         else:
                             kid_rels = '+'.join(rels_wo_span)
                         strad_rels.append(kid_rels)
-                        # WIP running counter of straddling relations
+                        # WIP list of straddling relations
                         strad_rels_rows.append({
                             'sent_id': '{}_sent{}'.format(doc_id.doc, sent_idx),
                             'kid_rels': kid_rels,
@@ -582,27 +609,30 @@ def load_training_as_dataframe_new(binarize=False):
                     # add info to row
                     row.update({
                         # parent span, in EDUs
-                        'parent_span_start': parent_span[0],
-                        'parent_span_end': parent_span[1],
+                        'parent_edu_start': parent_span[0],
+                        'parent_edu_end': parent_span[1],
                         # length of parent span, in sentences
-                        'parent_span_sent_len': (
+                        'parent_sent_len': (
                             edu2sent[parent_span[1] - 1] -
                             edu2sent[parent_span[0] - 1] + 1),
                         # distance between the current sentence and the most
                         # remote sentence covered by the parent span,
                         # in sentences
-                        'parent_span_sent_dist': (
+                        'parent_sent_dist': (
                             max([(edu2sent[parent_span[1] - 1] - sent_idx),
                                  (sent_idx - edu2sent[parent_span[0] - 1])])),
                         # types of leaky, in the taxonomy of
                         # (van der Vliet et al. 2011)
-                        # currently {1,2} vs {3,4}
-                        'leaky_type_12': leaky_type_12,
+                        'leaky_type': leaky_type,
                     })
                 else:
                     row.update({
-                        'parent_span_start': row['edu_span_start'],
-                        'parent_span_end': row['edu_span_end'],
+                        'parent_span_start': row['edu_start'],
+                        'parent_span_end': row['edu_end'],
+                        # default value for leaky_type, provides a mean for
+                        # easy comparison on complex sentences, between
+                        # non-leaky and the various types of leaky
+                        'leaky_type': 0,
                     })
                 # end WIP
             doc_sent_rows.append(row)
@@ -640,21 +670,21 @@ def load_training_as_dataframe_new(binarize=False):
                 row = {
                     # data directly from the paragraph segmenter
                     'para_id': '{}_para{}'.format(doc_id.doc, para_idx),
-                    'span_start': para_span.char_start,
-                    'span_end': para_span.char_end,
+                    'char_start': para_span.char_start,
+                    'char_end': para_span.char_end,
                 }
                 # paragraph <-> EDU mapping dependent data
                 # should probably have its own dataframe etc.
                 if para_idx in edu2para_codom:
                     row.update({
-                        'edu_span_start': para_edu_starts[para_idx],
-                        'edu_span_end': para_edu_ends[para_idx],
+                        'edu_start': para_edu_starts[para_idx],
+                        'edu_end': para_edu_ends[para_idx],
                         # computed column
-                        'edu_span_len': (para_edu_ends[para_idx] -
-                                         para_edu_starts[para_idx]) + 1,
+                        'edu_len': (para_edu_ends[para_idx] -
+                                    para_edu_starts[para_idx]) + 1,
                     })
                     # use paragraph <-> RST tree alignment
-                    if row['edu_span_len'] > 1:  # complex paragraphs only
+                    if row['edu_len'] > 1:  # complex paragraphs only
                         row.update({
                             'leaky': ((para_edu_starts[para_idx],
                                        para_edu_ends[para_idx])
@@ -676,23 +706,23 @@ def load_training_as_dataframe_new(binarize=False):
                         # add info to row
                         row.update({
                             # parent span, on EDUs
-                            'parent_span_start': parent_span[0],
-                            'parent_span_end': parent_span[1],
+                            'parent_edu_start': parent_span[0],
+                            'parent_edu_end': parent_span[1],
                             # length of parent span, in paragraphs
-                            'parent_span_para_len': (
+                            'parent_para_len': (
                                 edu2para[parent_span[1] - 1] -
                                 edu2para[parent_span[0] - 1] + 1),
                             # distance between the current paragraph and the most
                             # remote paragraph covered by the parent span, in
                             # paragraphs
-                            'parent_span_para_dist': (
+                            'parent_para_dist': (
                                 max([(edu2para[parent_span[1] - 1] - para_idx),
                                      (para_idx - edu2para[parent_span[0] - 1])])),
                         })
                     else:
                         row.update({
-                            'parent_span_start': row['edu_span_start'],
-                            'parent_span_end': row['edu_span_end'],
+                            'parent_edu_start': row['edu_start'],
+                            'parent_edu_end': row['edu_end'],
                         })
                     # end WIP
                 doc_para_rows.append(row)
@@ -743,16 +773,17 @@ if False:
 
 # SENTENCES
 # complex sentences
-complex_sents = sents_train[sents_train.edu_span_len > 1]
+complex_sents = sents_train[sents_train['edu_len'] > 1]
 print('Complex: {} / {} = {}'.format(
     len(complex_sents), len(sents_train),
     float(len(complex_sents)) / len(sents_train)))
 
 # leaky sentences
 # assert there is no sentence which is leaky but not complex
-assert sents_train[sents_train.leaky & (sents_train.edu_span_len <= 1)].empty
+assert sents_train[sents_train['leaky'] &
+                   (sents_train['edu_len'] <= 1)].empty
 # proportion of leaky sentences
-leaky_sents = sents_train[sents_train.leaky]
+leaky_sents = sents_train[sents_train['leaky']]
 # according to (Soricut and Marcu, 2003), p. 2, should be 323/6132 = 5.3%
 print('Leaky: {} / {} = {}'.format(
     len(leaky_sents), len(sents_train),
@@ -765,7 +796,7 @@ print()
 
 # compare leaky with non-leaky complex sentences: EDU length
 print('EDU span length of leaky vs non-leaky complex sentences')
-print(complex_sents.groupby('leaky')['edu_span_len'].describe().unstack())
+print(complex_sents.groupby('leaky')['edu_len'].describe().unstack())
 print()
 
 # for each leaky sentence, number of sentences included in the smallest
@@ -777,15 +808,18 @@ print()
 # new hypothesis: 75% of leaky sentences can be split so that their EDUs
 # + the neighboring sentences form complete spans
 if False:
-    print(leaky_sents[['parent_span_sent_len', 'parent_span_sent_dist']].describe(
+    print(leaky_sents[['parent_sent_len', 'parent_sent_dist']].describe(
         percentiles=[.1, .2, .3, .4, .5, .6, .7, .8, .9]))
-    print(leaky_sents[(leaky_sents['parent_span_sent_dist'] == 1)].describe())
-    print(leaky_sents[(leaky_sents['parent_span_sent_dist'] == 1) &
-                      (leaky_sents['parent_span_sent_len'] > 2)])
+    print(leaky_sents[(leaky_sents['parent_sent_dist'] == 1)].describe())
+    print(leaky_sents[(leaky_sents['parent_sent_dist'] == 1) &
+                      (leaky_sents['parent_sent_len'] > 2)])
 if False:
-    print(leaky_sents['parent_span_sent_len'].value_counts())
+    print(leaky_sents['parent_sent_len'].value_counts())
 # taxonomy of leaky sentences
-print(leaky_sents.groupby('leaky_type_12')['edu_span_len'].describe().unstack())
+print(complex_sents.groupby('leaky_type')['edu_len'].describe().unstack())
+print(complex_sents.groupby('edu_len')['leaky_type'].value_counts(normalize=False).unstack())  # absolute value counts
+print(complex_sents.groupby('edu_len')['leaky_type'].value_counts(normalize=True).unstack())  # normalized value counts
+
 
 # WIP straddling relations
 strad_rels_df = pd.DataFrame(strad_rels_rows)
@@ -794,21 +828,22 @@ print(strad_rels_df['sent_id'].describe()['count'])
 print(strad_rels_df.groupby(['kid_rels']).describe()['sent_id'].unstack().sort_values('count', ascending=False))
 # compare to distribution of intra/inter relations
 print()
-# print(rels_train.groupby('  # RESUME HERE
+print(rels_train[rels_train['edu_len'] > 2].groupby(['intra_sent', 'strad_sent'])['kid_rels'].value_counts(normalize=True))
 
 # PARAGRAPHS
 if False:
     # complex paragraphs
-    complex_paras = paras_train[paras_train.edu_span_len > 1]
+    complex_paras = paras_train[paras_train['edu_len'] > 1]
     print('Complex: {} / {} = {}'.format(
         len(complex_paras), len(paras_train),
         float(len(complex_paras)) / len(paras_train)))
 
     # leaky paragraphs
     # assert there is no paragraph which is leaky but not complex
-    assert paras_train[paras_train.leaky & (paras_train.edu_span_len <= 1)].empty
+    assert paras_train[paras_train['leaky'] &
+                       (paras_train['edu_span_len'] <= 1)].empty
     # proportion of leaky paragraphs
-    leaky_paras = paras_train[paras_train.leaky]
+    leaky_paras = paras_train[paras_train['leaky']]
     print('Leaky: {} / {} = {}'.format(
         len(leaky_paras), len(paras_train),
         float(len(leaky_paras)) / len(paras_train)))

--- a/educe/rst_dt/document_plus.py
+++ b/educe/rst_dt/document_plus.py
@@ -11,6 +11,7 @@ from educe.external.postag import Token
 from educe.util import relative_indices
 from .text import Sentence, Paragraph, clean_edu_text
 from .annotation import EDU
+from .ptb import align_edus_with_sentences
 
 
 # helpers for _align_with_doc_structure
@@ -292,9 +293,9 @@ class DocumentPlus(object):
         self.edu2tokens = edu2tokens
         return self
 
-    # TODO move functionality to ptb.py
     def align_with_trees(self, strict=False):
         """Compute for each EDU the overlapping trees"""
+        edus = self.edus
         syn_trees = self.tkd_trees
 
         # if there is no sentence segmentation from syntax,
@@ -303,56 +304,12 @@ class DocumentPlus(object):
             self.edu2sent = self.edu2raw_sent
             return self
 
-        edu2sent = []
-
-        edus = self.edus
-
-        # left padding EDU
+        # compute edu2sent, prepend 0 for lpad, shift all indices by 1
         assert edus[0].is_left_padding()
-        edu2sent.append(0)
-
-        # regular EDUs
-        for edu in edus[1:]:
-            tree_idcs = [t_idx
-                         for t_idx, tree in enumerate(syn_trees[1:], start=1)
-                         if tree is not None and tree.overlaps(edu)]
-
-            if len(tree_idcs) == 1:
-                tree_idx = tree_idcs[0]
-            elif len(tree_idcs) == 0:
-                # "no tree at all" can happen when the EDU text is totally
-                # absent from the list of sentences of this doc in the PTB
-                # ex: wsj_0696.out, last sentence
-                if strict:
-                    print(edu)
-                    emsg = 'No PTB tree for this EDU'
-                    raise ValueError(emsg)
-
-                tree_idx = None
-            else:
-                # more than one PTB trees overlap with this EDU
-                if strict:
-                    emsg = ('Segmentation mismatch:',
-                            'one EDU, more than one PTB tree')
-                    print(edu)
-                    ptrees = [syn_trees[t_idx] for t_idx in tree_idcs]
-                    for ptree in ptrees:
-                        print('    ', [str(leaf) for leaf in ptree.leaves()])
-                    raise ValueError(emsg)
-
-                # heuristics: pick the PTB tree with maximal overlap
-                # with the EDU span
-                len_espan = edu.span.length()
-                ovlaps = [syn_trees[tree_idx].overlaps(edu).length()
-                          for tree_idx in tree_idcs]
-                ovlap_ratios = [float(ovlap) / len_espan
-                                for ovlap in ovlaps]
-                # find the argmax
-                max_idx = ovlap_ratios.index(max(ovlap_ratios))
-                tree_idx = tree_idcs[max_idx]
-
-            edu2sent.append(tree_idx)
-
+        edu2sent = align_edus_with_sentences(self.edus[1:], syn_trees[1:],
+                                             strict=strict)
+        edu2sent = [0] + [(i+1 if i is not None else i)
+                          for i in edu2sent]
         self.edu2sent = edu2sent
 
         # compute relative index of each EDU from the beginning (resp. to

--- a/educe/rst_dt/parse.py
+++ b/educe/rst_dt/parse.py
@@ -19,10 +19,8 @@ import codecs
 from nltk import Tree
 
 from educe.annotation import Span
-from .annotation import\
-    RSTTreeException,\
-    EDU, Node,\
-    RSTContext, RSTTree, SimpleRSTTree
+from .annotation import (EDU, Node, RSTContext, RSTTree, RSTTreeException,
+                         SimpleRSTTree)
 from .rst_wsj_corpus import load_rst_wsj_corpus_text_file
 from ..external.postag import generic_token_spans
 from ..internalutil import treenode
@@ -50,7 +48,7 @@ def _process_text(matchobj):
     """
     text = matchobj.group("text")
     return "[%s]" % text
-    #.replace(" ","¤")
+    # .replace(" ","¤")
 
 
 def _process_head(matchobj):
@@ -131,8 +129,8 @@ def _tree_span(tree):
     """
     Span for the current node or leaf in the tree
     """
-    return treenode(tree).span if isinstance(tree, Tree)\
-        else tree.span
+    return (treenode(tree).span if isinstance(tree, Tree)
+            else tree.span)
 
 
 def _postprocess(tree, start=0, edu_start=1):


### PR DESCRIPTION
This PR adds functions to gather information about leaky sentences in the RST-WSJ corpus.

Corpus reading utilities need to be slightly adjusted to provide the necessary sentence segmentation (mostly to align tokens and sentences with EDUs).
As I could not come up with an alternative, coherent factoring for these functionalities, I ended up adding a few functions that are 99% duplicates of existing ones.
This should obviously be remedied as soon as possible: I need a simple, robust, versatile and clean layout for corpus reading utilities.