### PR TITLE
FIX educe.stac.sanity.main: common subset of Python 2 and 3

### DIFF
--- a/educe/stac/sanity/main.py
+++ b/educe/stac/sanity/main.py
@@ -281,7 +281,7 @@ class SanityChecker(object):
         reader = stac.Reader(corpus_dir)
         all_files = reader.files()
         self.anno_files = reader.filter(all_files, is_interesting)
-        interesting = self.anno_files.keys()
+        interesting = list(self.anno_files)  # or list(self.anno_files.keys())
         for key in interesting:
             ukey = twin_key(key, 'unannotated')
             if ukey in all_files:


### PR DESCRIPTION
Iterating over dictionaries has changed in Python 3.
This change aims at preserving the same semantics in the common subset of Python 2 and 3.