### PR TITLE
ENH weaving phases for STAC

### DIFF
--- a/educe/annotation.py
+++ b/educe/annotation.py
@@ -181,7 +181,7 @@ class Span(object):
 # pylint: disable=invalid-name
 class RelSpan(object):
     """
-    Which two units a relation connections.
+    Which two units a relation connects.
     """
     def __init__(self, t1, t2):
         self.t1 = t1
@@ -370,14 +370,27 @@ class Unit(Annotation):
 
 
 class Relation(Annotation):
-    """
-    An annotation between two annotations.
+    """An annotation between two annotations.
+
     Relations are directed; see `RelSpan` for details
 
     Use the `source` and `target` field to grab these respective
     annotations, but note that they are only instantiated after
     `fleshout` is called (corpus slurping normally fleshes out
-    documents and thus their relations)
+    documents and thus their relations).
+
+    Parameters
+    ----------
+    rel_id : string
+        Relation id
+    span : RelSpan
+        Pair of units connected by this relation
+    rtype : string
+        Relation type
+    features : dict
+        Features
+    metadata : TODO
+        TODO
     """
     def __init__(self, rel_id, span, rtype, features, metadata=None):
         Annotation.__init__(self, rel_id, span, rtype, features, metadata)

--- a/educe/rst_dt/dep2con.py
+++ b/educe/rst_dt/dep2con.py
@@ -13,7 +13,7 @@ import itertools
 
 from .annotation import SimpleRSTTree, Node
 from .corpus_diagnostics import (get_most_frequent_unuc,
-                                 load_training_as_dataframe)
+                                 load_corpus_as_dataframe)
 from .deptree import RstDtException, NUC_N, NUC_S, NUC_R
 from ..internalutil import treenode
 
@@ -63,7 +63,7 @@ class DummyNuclearityClassifier(object):
             multinuc_lbls.extend(['joint', 'same-unit', 'textual'])
 
         elif self.strategy == "most_frequent_by_rel":
-            train_df = load_training_as_dataframe()
+            train_df = load_corpus_as_dataframe(selection='train')
             multinuc_lbls.extend(rel_name for rel_name, mode_unuc
                                  in get_most_frequent_unuc(train_df).items()
                                  if mode_unuc == 'NN')

--- a/educe/rst_dt/dep2con.py
+++ b/educe/rst_dt/dep2con.py
@@ -63,10 +63,9 @@ class DummyNuclearityClassifier(object):
             multinuc_lbls.extend(['joint', 'same-unit', 'textual'])
 
         elif self.strategy == "most_frequent_by_rel":
+            train_df = load_training_as_dataframe()
             multinuc_lbls.extend(rel_name for rel_name, mode_unuc
-                                 in get_most_frequent_unuc(
-                                     load_training_as_dataframe()
-                                 ).items()
+                                 in get_most_frequent_unuc(train_df).items()
                                  if mode_unuc == 'NN')
         self.multinuc_lbls = multinuc_lbls
 

--- a/educe/stac/annotation.py
+++ b/educe/stac/annotation.py
@@ -465,7 +465,7 @@ def create_units(_, doc, author, partial_units):
     """
     # It seems like Glozz uses the creation-date metadata field to
     # identify units (symptom: units that have different ids, but
-    # some date don't appear in UI).
+    # same date don't appear in UI).
     #
     # Also, other tools in the STAC pipeline seem to use the convention
     # of negative numbers for fields where the notion of a creation date

--- a/educe/stac/annotation.py
+++ b/educe/stac/annotation.py
@@ -123,7 +123,7 @@ def split_turn_text(text):
 
     Mind your offsets! They're based on the whole turn string.
     """
-    prefix_re = re.compile(r'(^[0-9]+ ?: .*? ?: )(.*)$')
+    prefix_re = re.compile(r'(^[0-9]+(?:[.][0-9]+)* ?: .*? ?: )(.*)$')
     match = prefix_re.match(text)
     if match:
         return (match.group(1), match.group(2))
@@ -134,13 +134,15 @@ def split_turn_text(text):
                         text)
 
 
+def parse_turn_id(turn_id_str):
+    """Parse a turn identifier akin to a Gorn address from a string."""
+    return tuple(int(x) for x in turn_id_str.split('.'))
+
+
 def turn_id(anno):
-    """
-    Return as an integer the turn number associated with a turn
-    annotation (or None if this information is missing).
-    """
+    """Get the turn identifier for a turn annotation (or None)."""
     tid_str = anno.features.get('Identifier')
-    return int(tid_str) if tid_str is not None else None
+    return parse_turn_id(tid_str) if tid_str is not None else None
 
 
 def addressees(anno):
@@ -238,6 +240,12 @@ def is_turn(annotation):
     """
     return (isinstance(annotation, Unit) and
             annotation.type == 'Turn')
+
+
+def is_paragraph(annotation):
+    """See Unit typology above"""
+    return (isinstance(annotation, Unit) and
+            annotation.type.lower() == 'paragraph')
 
 
 def is_turn_star(annotation):

--- a/educe/stac/edit/cmd/__init__.py
+++ b/educe/stac/edit/cmd/__init__.py
@@ -21,21 +21,22 @@ from . import (delete_anno,
 # subcommands into sections, but maybe we can wait for it to grow such
 # a feature, or write our own formatter class, or just abuse the command
 # epilog
-SUBCOMMAND_SECTIONS =\
-    [('Annotation ids',
-      [rename,
-       delete_anno,
-       rewrite]),
-     ('Boundaries',
-      [merge_dialogue,
-       merge_edus,
-       split_dialogue,
-       split_edu,
-       nudge,
-       nudge_dialogue]),
-     ('Block editing',
-      [insert,
-       move])]
+SUBCOMMAND_SECTIONS = [
+    ('Annotation ids',
+     [rename,
+      delete_anno,
+      rewrite]),
+    ('Boundaries',
+     [merge_dialogue,
+      merge_edus,
+      split_dialogue,
+      split_edu,
+      nudge,
+      nudge_dialogue]),
+    ('Block editing',
+     [insert,
+      move])
+]
 
 SUBCOMMANDS = []
 for descr, section in SUBCOMMAND_SECTIONS:

--- a/educe/stac/edit/cmd/merge_dialogue.py
+++ b/educe/stac/edit/cmd/merge_dialogue.py
@@ -12,6 +12,7 @@ import sys
 from educe.annotation import Span
 from educe.glozz import GlozzException
 
+from educe.stac.annotation import parse_turn_id
 from educe.stac.util.annotate import annotate_doc
 from educe.stac.util.args import\
     add_usual_input_args, add_usual_output_args, anno_id,\
@@ -141,7 +142,7 @@ def config_argparser(parser):
                               nargs='+',
                               help='eg. stac_39819045 stac_98871771')
     parser_mutex.add_argument('--turns',
-                              metavar='INT', type=int,
+                              metavar='TURN_ID', type=parse_turn_id,
                               nargs=2,
                               help='eg. 187 192')
     add_commit_args(parser)
@@ -158,7 +159,8 @@ def commit_msg(args, corpus, k, sought):
     dialogues = [_get_annotation_with_id(d, doc.units) for d in sought]
     if dialogues:
         title_fmt = u"{doc}_{subdoc}: merge dialogues{hint}"
-        title_hint = " (turns %d-%d)" % tuple(args.turns) if args.turns else ""
+        title_hint = (" (turns {}-{})".format(args.turns[0], args.turns[1])
+                      if args.turns else "")
         dspan = _merge_spans(dialogues)
         lines = [title_fmt.format(doc=k.doc,
                                   subdoc=k.subdoc,

--- a/educe/stac/edit/cmd/nudge_dialogue.py
+++ b/educe/stac/edit/cmd/nudge_dialogue.py
@@ -13,6 +13,7 @@ import sys
 from educe.annotation import Span
 import educe.stac as st
 
+from educe.stac.annotation import parse_turn_id
 from educe.stac.util.annotate import show_diff, annotate_doc
 from educe.stac.util.args import\
     add_usual_input_args, add_usual_output_args,\
@@ -49,7 +50,7 @@ def _nudge_up(turn, dialogue, next_turn, prev_dialogue):
         sys.exit("Can't move very last turn. "
                  "Try `stac-util merge-dialogue` instead")
     elif not prev_dialogue:
-        sys.exit("Can't move from first dialogue."
+        sys.exit("Can't move from first dialogue. "
                  "Try `stac-util move` instead")
     elif turn.span.char_start - 1 != dialogue.span.char_start:
         sys.exit("Turn %d %s is not at the start of its dialogue %s" %
@@ -113,16 +114,18 @@ def _nudge_dialogue(doc, tid, direction):
     Move a turn either up or down.
     For feedback purposes, return the span of the affected region
     """
-    prev_turn, turn, next_turn = \
-        _window1(lambda x: st.turn_id(x) == tid,
-                 [x for x in doc.units if st.is_turn(x)])
+    prev_turn, turn, next_turn = _window1(
+        lambda x: st.turn_id(x) == tid,
+        [x for x in doc.units if st.is_turn(x)]
+    )
     if not turn:
         sys.exit("Could not find turn %d" % tid)
 
     tspan = turn.text_span()
-    prev_dialogue, dialogue, next_dialogue = \
-        _window1(lambda x: x.text_span().encloses(tspan),
-                 [x for x in doc.units if st.is_dialogue(x)])
+    prev_dialogue, dialogue, next_dialogue = _window1(
+        lambda x: x.text_span().encloses(tspan),
+        [x for x in doc.units if st.is_dialogue(x)]
+    )
 
     if direction == "up":
         return _nudge_up(turn, dialogue, next_turn, prev_dialogue)
@@ -149,7 +152,7 @@ def config_argparser(parser):
     add_usual_input_args(parser, doc_subdoc_required=True)
     add_usual_output_args(parser, default_overwrite=True)
     add_commit_args(parser)
-    parser.add_argument('turn', metavar='TURN', type=int,
+    parser.add_argument('turn', metavar='TURN', type=parse_turn_id,
                         help='turn number')
     parser.add_argument('direction', choices=["up", "down"],
                         help='move turn up or down')

--- a/educe/stac/edit/cmd/nudge_dialogue.py
+++ b/educe/stac/edit/cmd/nudge_dialogue.py
@@ -30,8 +30,8 @@ def _mini_diff(k, args, old_doc, new_doc, span):
     """
     mini_old_doc = narrow_to_span(old_doc, span)
     mini_new_doc = narrow_to_span(new_doc, span)
-    return ["======= NUDGE TURN %d %s in %s ========" %
-            (args.turn, args.direction, k),
+    return ["======= NUDGE TURN {} {} in {} ========".format(
+        args.turn, args.direction, k),
             "...",
             show_diff(mini_old_doc, mini_new_doc),
             "...",
@@ -170,8 +170,8 @@ def commit_msg(info):
     k = info.key
     mini_new_doc = narrow_to_span(info.after, info.span)
 
-    lines = ["%s_%s: move turn %d %s" % (k.doc, k.subdoc,
-                                         info.tid, info.direction),
+    lines = ["{}_{}: move turn {} {}".format(
+        k.doc, k.subdoc, info.tid, info.direction),
              "",
              annotate_doc(mini_new_doc),
              "..."]

--- a/educe/stac/edit/cmd/split_dialogue.py
+++ b/educe/stac/edit/cmd/split_dialogue.py
@@ -15,14 +15,14 @@ import sys
 from educe.annotation import Span
 import educe.stac as st
 
+from educe.stac.annotation import parse_turn_id
 from educe.stac.util.annotate import show_diff, annotate_doc
-from educe.stac.util.args import\
-    add_usual_input_args, add_usual_output_args,\
-    add_commit_args,\
-    read_corpus, get_output_dir, announce_output_dir
-from educe.stac.util.glozz import\
-    (TimestampCache,
-     set_anno_author, set_anno_date)
+from educe.stac.util.args import (add_usual_input_args, add_usual_output_args,
+                                  add_commit_args,
+                                  read_corpus, get_output_dir,
+                                  announce_output_dir)
+from educe.stac.util.glozz import (TimestampCache,
+                                   set_anno_author, set_anno_date)
 from educe.stac.util.doc import narrow_to_span
 from educe.stac.util.output import save_document
 
@@ -35,8 +35,7 @@ def _mini_diff(k, args, old_doc, new_doc, span):
     """
     mini_old_doc = narrow_to_span(old_doc, span)
     mini_new_doc = narrow_to_span(new_doc, span)
-    return ["======= SPLIT AT TURN %d in %s ========" %
-            (args.turn, k),
+    return ["======= SPLIT AT TURN {} in {} ========".format(args.turn, k),
             "...",
             show_diff(mini_old_doc, mini_new_doc),
             "...",
@@ -91,7 +90,7 @@ def _split_dialogue(tcache, doc, tid):
     Span for the dialogue that was split
     """
 
-    wanted_t = 'turn %d' % tid
+    wanted_t = 'turn {}'.format(tid)
     wanted_d = 'dialogue for ' + wanted_t
     turn = _the(wanted_t, [x for x in doc.units if st.is_turn(x) and
                            st.turn_id(x) == tid])
@@ -119,7 +118,7 @@ def config_argparser(parser):
     add_usual_input_args(parser, doc_subdoc_required=True)
     add_usual_output_args(parser, default_overwrite=True)
     add_commit_args(parser)
-    parser.add_argument('turn', metavar='TURN', type=int,
+    parser.add_argument('turn', metavar='TURN', type=parse_turn_id,
                         help='turn number')
     parser.set_defaults(func=main)
 
@@ -135,8 +134,8 @@ def commit_msg(info):
     k = info.key
     mini_new_doc = narrow_to_span(info.after, info.span)
 
-    lines = [("%s_%s: split dialogue before turn %d" %
-              (k.doc, k.subdoc, info.tid)),
+    lines = ["{}_{}: split dialogue before turn {}".format(
+        k.doc, k.subdoc, info.tid),
              "",
              annotate_doc(mini_new_doc),
              "..."]

--- a/educe/stac/oneoff/cmd/__init__.py
+++ b/educe/stac/oneoff/cmd/__init__.py
@@ -10,19 +10,24 @@ stac-oneoff subcommands
 from . import (clean_emoticons,
                clean_schemas,
                clean_dialogue_acts,
+               delete_text,
+               replace_text,
                weave)
 
 # at the time of this writing argparse doesn't support a way to group
 # subcommands into sections, but maybe we can wait for it to grow such
 # a feature, or write our own formatter class, or just abuse the command
 # epilog
-SUBCOMMAND_SECTIONS =\
-    [('Cleanups',
-      [clean_emoticons,
-       clean_schemas,
-       clean_dialogue_acts]),
-     ('Invasive',
-      [weave])]
+SUBCOMMAND_SECTIONS = [
+    ('Cleanups',
+     [clean_emoticons,
+      clean_schemas,
+      clean_dialogue_acts]),
+    ('Invasive',
+     [weave,
+      delete_text,
+      replace_text])
+]
 
 SUBCOMMANDS = []
 for descr, section in SUBCOMMAND_SECTIONS:

--- a/educe/stac/oneoff/cmd/clean_emoticons.py
+++ b/educe/stac/oneoff/cmd/clean_emoticons.py
@@ -15,12 +15,11 @@ from educe.stac.context import sorted_first_widest
 from educe.stac.graph import EnclosureGraph
 from educe.stac.util.annotate import show_diff
 from educe.stac.util.doc import retarget
-from educe.stac.util.glozz import\
-    (TimestampCache, set_anno_author, set_anno_date)
-from educe.stac.util.args import\
-    (add_usual_output_args,
-     read_corpus_with_unannotated,
-     get_output_dir, announce_output_dir)
+from educe.stac.util.glozz import (TimestampCache, set_anno_author,
+                                   set_anno_date)
+from educe.stac.util.args import (add_usual_output_args,
+                                  read_corpus_with_unannotated,
+                                  get_output_dir, announce_output_dir)
 from educe.stac.util.output import save_document
 from educe.util import add_corpus_filters, fields_without
 

--- a/educe/stac/oneoff/cmd/delete_text.py
+++ b/educe/stac/oneoff/cmd/delete_text.py
@@ -1,0 +1,213 @@
+"""Delete a text span in a document.
+
+"""
+
+from __future__ import print_function
+import copy
+import sys
+
+from educe.annotation import Span, Unit
+import educe.stac
+from educe.stac.annotation import is_turn
+from educe.stac.edit.cmd.move import is_requested
+from educe.stac.util.annotate import annotate_doc, show_diff
+from educe.stac.util.args import (add_commit_args,
+                                  add_usual_input_args,
+                                  add_usual_output_args,
+                                  announce_output_dir,
+                                  comma_span,
+                                  get_output_dir)
+from educe.stac.util.doc import evil_set_text
+from educe.stac.util.output import save_document
+
+
+NAME = 'delete-text'
+
+
+def delete_text_at_span(doc, span, minor=True):
+    """Delete text at `span` in `doc`.
+
+    Parameters
+    ----------
+    doc : Document
+        Original document
+    span : Span
+        Span of the substitution site
+    minor : boolean, default True
+        If True, the text deletion is considered minor and annotations
+        are kept as they are (with shifted spans) ; otherwise unit
+        annotations and discourse relations are deleted.
+
+    Returns
+    -------
+    doc2 : Document
+        Updated document
+    del_annos : set of Annotation
+        Deleted annotations
+    """
+    def shift_anno(anno, offset, point):
+        """Get a shifted copy of an annotation"""
+        anno2 = copy.deepcopy(anno)
+        if not isinstance(anno, Unit):
+            return anno2
+
+        anno_span = anno2.text_span()
+        if anno_span.char_start >= point:
+            # if the annotation is entirely after the deletion site,
+            # shift the whole span
+            anno2.span = anno_span.shift(offset)
+        elif anno_span.char_end >= point:
+            # if the annotation straddles the substitution site,
+            # stretch (shift its end)
+            anno2.span = Span(anno_span.char_start,
+                              anno_span.char_end + offset)
+        return anno2
+
+    # compute text update
+    old_txt = doc.text()
+    new_txt = old_txt[:span.char_start] + old_txt[span.char_end:]
+    offset = len(new_txt) - len(old_txt)
+    point = span.char_end
+    # create a copy of the doc
+    doc2 = copy.copy(doc)
+    evil_set_text(doc2, new_txt)
+    # shift or stretch all units
+    # if not minor, skip annotations in the subsitution site so that
+    # they get lost
+    if minor:
+        doc2.units = [shift_anno(x, offset, point)
+                      for x in doc.units]
+        doc2.schemas = [shift_anno(x, offset, point)
+                        for x in doc.schemas]
+        doc2.relations = [shift_anno(x, offset, point)
+                          for x in doc.relations]
+    else:
+        deleted_units = set(x for x in doc.units
+                            if span.encloses(x.text_span()))
+        # fixed point deletion of schemas and relations
+        deleted_schms = set(x for x in doc.schemas
+                            if any(y in deleted_units for y in x.members))
+        deleted_rels = set(x for x in doc.relations
+                           if (x.source in deleted_units or
+                               x.target in deleted_units))
+        new_del_schms = deleted_schms
+        new_del_rels = deleted_rels
+        while new_del_schms or new_del_rels:
+            next_del_schms = set(x for x in doc.schemas
+                                 if any(y in new_del_schms
+                                        for y in x.members))
+            next_del_rels = set(x for x in doc.relations
+                                if (x.source in new_del_rels or
+                                    x.target in new_del_rels))
+            deleted_schms.update(next_del_schms)
+            deleted_rels.update(next_del_rels)
+            new_del_schms = next_del_schms
+            new_del_rels = next_del_rels
+        # shift everything we keep
+        doc2.units = [shift_anno(x, offset, point) for x in doc.units
+                      if x not in deleted_units]
+        doc2.schemas = [shift_anno(x, offset, point) for x in doc.schemas
+                        if x not in deleted_schms]
+        doc2.relations = [shift_anno(x, offset, point) for x in doc.relations
+                          if x not in deleted_rels]
+    # TODO print deleted_units, deleted_rels, deleted_schms
+    del_annos = (deleted_units, deleted_schms, deleted_rels)
+    return doc2, del_annos
+
+
+def commit_msg(key, anno_str_before, all_del_annos):
+    """Generate a commit message describing the operation we just did.
+
+    """
+    lines = [
+        "{}_{}: very scary edit (delete text)".format(
+            key.doc, key.subdoc),
+        "",
+        "    " + anno_str_before,
+        "==> " + '',
+        ""
+    ]
+
+    if all_del_annos:
+        lines.append("======= Deleted annotations =======")
+    for tgt_k, del_annos in sorted(all_del_annos):
+        lines.append(
+            '------- {}{} -------'.format(
+                tgt_k.stage,
+                (' / ' + tgt_k.annotator if tgt_k.annotator is not None
+                 else ''))
+        )
+        if del_annos[0]:
+            lines.append(
+                'Units: ' + ', '.join(sorted(
+                    str(x.local_id()) for x in del_annos[0]))
+            )
+        if del_annos[1]:
+            lines.append(
+                'Schemas: ' + ', '.join(sorted(
+                    str(x.local_id()) for x in del_annos[1]))
+            )
+        if del_annos[2]:
+            lines.append(
+                'Relations: ' + ', '.join(sorted(
+                    str(x.local_id()) for x in del_annos[2]))
+            )
+
+    return "\n".join(lines)
+
+
+def config_argparser(parser):
+    """Subcommand flags.
+
+    You should create and pass in the subparser to which the flags
+    are to be added.
+    """
+    add_usual_input_args(parser, doc_subdoc_required=True,
+                         help_suffix='to insert into')
+    parser.add_argument('--span', metavar='SPAN', type=comma_span,
+                        required=True,
+                        help='span of the substitution site')
+    parser.add_argument('--minor', action='store_true',
+                        help='minor fix, leave annotations as they are')
+    add_usual_output_args(parser, default_overwrite=True)
+    add_commit_args(parser)
+    parser.set_defaults(func=main)
+
+
+def main(args):
+    """Subcommand main.
+
+    You shouldn't need to call this yourself if you're using
+    `config_argparser`.
+    """
+    output_dir = get_output_dir(args, default_overwrite=True)
+
+    # locate insertion site: target document
+    reader = educe.stac.Reader(args.corpus)
+    tgt_files = reader.filter(reader.files(), is_requested(args))
+    tgt_corpus = reader.slurp(tgt_files)
+
+    # TODO mark units with FIXME, optionally delete in/out relations
+    span = args.span
+    minor = args.minor
+    # store before/after
+    annos_before = []
+    all_del_annos = []
+    for tgt_k, tgt_doc in tgt_corpus.items():
+        annos_before.append(annotate_doc(tgt_doc, span=span))
+        # process
+        new_tgt_doc, del_annos = delete_text_at_span(
+            tgt_doc, span, minor=minor)
+        all_del_annos.append((tgt_k, del_annos))
+        # show diff and save doc
+        diffs = ["======= DELETE TEXT IN %s   ========" % tgt_k,
+                 show_diff(tgt_doc, new_tgt_doc)]
+        print("\n".join(diffs).encode('utf-8'), file=sys.stderr)
+        save_document(output_dir, tgt_k, new_tgt_doc)
+    announce_output_dir(output_dir)
+    # commit message
+    tgt_k, tgt_doc = list(tgt_corpus.items())[0]
+    anno_str_before = annos_before[0]
+    if tgt_k and not args.no_commit_msg:
+        print("-----8<------")
+        print(commit_msg(tgt_k, anno_str_before, all_del_annos))

--- a/educe/stac/oneoff/cmd/replace_text.py
+++ b/educe/stac/oneoff/cmd/replace_text.py
@@ -1,0 +1,197 @@
+"""Replace a text span in a document.
+
+"""
+
+from __future__ import print_function
+import copy
+import sys
+
+from educe.annotation import Span, Unit
+import educe.stac
+from educe.stac.annotation import is_turn
+from educe.stac.edit.cmd.move import is_requested
+from educe.stac.util.annotate import annotate_doc, show_diff
+from educe.stac.util.args import (add_commit_args,
+                                  add_usual_input_args,
+                                  add_usual_output_args,
+                                  announce_output_dir,
+                                  comma_span,
+                                  get_output_dir)
+from educe.stac.util.doc import evil_set_text
+from educe.stac.util.output import save_document
+
+
+NAME = 'replace-text'
+
+
+def replace_text_at_span(doc, span, sub_text, minor=True):
+    """Replace text at `span` in `doc` with `sub_text`.
+
+    Parameters
+    ----------
+    doc : Document
+        Original document
+    span : Span
+        Span of the substitution site
+    sub_text : string
+        Substitution text
+    minor : boolean, default True
+        If True, the text substitution is considered minor and annotations
+        are kept as they are ; otherwise unit annotations are marked FIXME
+        and discourse relations are deleted.
+
+    Returns
+    -------
+    doc2 : Document
+        Updated document
+    """
+    def shift_anno(anno, span_old, text_new):
+        """Get a shifted copy of an annotation"""
+        anno2 = copy.deepcopy(anno)
+        if not isinstance(anno, Unit):
+            return anno2
+        
+        offset = (len(text_new) -
+                  (span_old.char_end - span_old.char_start))
+
+        anno_span = anno2.text_span()
+        if anno_span.char_start >= span_old.char_end:
+            # if the annotation is entirely after the substitution site,
+            # shift the whole span
+            anno2.span = anno_span.shift(offset)
+        elif anno_span.char_end >= span_old.char_end:
+            # if the annotation straddles the substitution site,
+            # stretch (shift its end)
+            anno2.span = Span(anno_span.char_start,
+                              anno_span.char_end + offset)
+        return anno2
+
+    # compute text update
+    old_txt = doc.text()
+    new_txt = old_txt[:span.char_start] + sub_text + old_txt[span.char_end:]
+    offset = len(new_txt) - len(old_txt)
+    point = span.char_end
+    # create a copy of the doc
+    doc2 = copy.copy(doc)
+    evil_set_text(doc2, new_txt)
+    # shift or stretch all units
+    # if not minor, skip annotations in the subsitution site so that
+    # they get lost
+    if minor:
+        doc2.units = [shift_anno(x, span, sub_text)
+                      for x in doc.units]
+        doc2.schemas = [shift_anno(x, span, sub_text)
+                        for x in doc.schemas]
+        doc2.relations = [shift_anno(x, span, sub_text)
+                          for x in doc.relations]
+    else:
+        deleted_units = set(x for x in doc.units
+                            if span.encloses(x.text_span()))
+        # fixed point deletion of schemas and relations
+        deleted_schms = set(x for x in doc.schemas
+                            if any(y in deleted_units for y in x.members))
+        deleted_rels = set(x for x in doc.relations
+                           if (x.source in deleted_units or
+                               x.target in deleted_units))
+        new_del_schms = deleted_schms
+        new_del_rels = deleted_rels
+        while new_del_schms or new_del_rels:
+            next_del_schms = set(x for x in doc.schemas
+                                 if any(y in new_del_schms
+                                        for y in x.members))
+            next_del_rels = set(x for x in doc.relations
+                                if (x.source in new_del_rels or
+                                    x.target in new_del_rels))
+            deleted_schms.update(next_del_schms)
+            deleted_rels.update(next_del_rels)
+            new_del_schms = next_del_schms
+            new_del_rels = next_del_rels
+        # shift everything we keep
+        doc2.units = [shift_anno(x, span, sub_text) for x in doc.units
+                      if x not in deleted_units]
+        doc2.schemas = [shift_anno(x, span, sub_text) for x in doc.schemas
+                        if x not in deleted_schms]
+        doc2.relations = [shift_anno(x, span, sub_text) for x in doc.relations
+                          if x not in deleted_rels]
+    # TODO print deleted_units, deleted_rels, deleted_schms
+    return doc2
+
+
+def commit_msg(key, anno_str_before, anno_str_after):
+    """Generate a commit message describing the operation we just did.
+
+    """
+    lines = [
+        "{}_{}: very scary edit (replace text)".format(
+            key.doc, key.subdoc),
+        "",
+        "    " + anno_str_before,
+        "==> " + anno_str_after
+    ]
+    return "\n".join(lines)
+
+
+def config_argparser(parser):
+    """Subcommand flags.
+
+    You should create and pass in the subparser to which the flags
+    are to be added.
+    """
+    add_usual_input_args(parser, doc_subdoc_required=True,
+                         help_suffix='to insert into')
+    parser.add_argument('--span', metavar='SPAN', type=comma_span,
+                        required=True,
+                        help='span of the substitution site')
+    parser.add_argument('--sub_text', metavar='TEXT',
+                        required=True,
+                        help='substitution text')
+    parser.add_argument('--minor', action='store_true',
+                        help='minor fix, leave annotations as they are')
+    add_usual_output_args(parser, default_overwrite=True)
+    add_commit_args(parser)
+    parser.set_defaults(func=main)
+
+
+def main(args):
+    """Subcommand main.
+
+    You shouldn't need to call this yourself if you're using
+    `config_argparser`.
+    """
+    output_dir = get_output_dir(args, default_overwrite=True)
+
+    # locate insertion site: target document
+    reader = educe.stac.Reader(args.corpus)
+    tgt_files = reader.filter(reader.files(), is_requested(args))
+    tgt_corpus = reader.slurp(tgt_files)
+
+    # TODO mark units with FIXME, optionally delete in/out relations
+    span = args.span
+    sub_text = args.sub_text
+    minor = args.minor
+    # store before/after
+    annos_before = []
+    annos_after = []
+    for tgt_k, tgt_doc in tgt_corpus.items():
+        annos_before.append(annotate_doc(tgt_doc, span=span))
+        # process
+        new_tgt_doc = replace_text_at_span(
+            tgt_doc, span, sub_text, minor=minor)
+        # WIP new_span, depends on the offset
+        offset = len(sub_text) - (span.char_end - span.char_start)
+        new_span = Span(span.char_start, span.char_end + offset)
+        # end WIP
+        annos_after.append(annotate_doc(new_tgt_doc, span=new_span))
+        # show diff and save doc
+        diffs = ["======= REPLACE TEXT IN %s   ========" % tgt_k,
+                 show_diff(tgt_doc, new_tgt_doc)]
+        print("\n".join(diffs).encode('utf-8'), file=sys.stderr)
+        save_document(output_dir, tgt_k, new_tgt_doc)
+    announce_output_dir(output_dir)
+    # commit message
+    tgt_k, tgt_doc = list(tgt_corpus.items())[0]
+    anno_str_before = annos_before[0]
+    anno_str_after = annos_after[0]
+    if tgt_k and not args.no_commit_msg:
+        print("-----8<------")
+        print(commit_msg(tgt_k, anno_str_before, anno_str_after))

--- a/educe/stac/sanity/checks/annotation.py
+++ b/educe/stac/sanity/checks/annotation.py
@@ -50,13 +50,22 @@ class FeatureItem(ContextItem):
         return parent
 # pylint: enable=too-many-arguments
 
-STAC_EXPECTED_FEATURES =\
-    {'EDU': frozenset(['Addressee', 'Surface_act']),
-     'relation': frozenset(['Argument_scope']),
-     'Resource': frozenset(['Status', 'Quantity', 'Correctness', 'Kind']),
-     'Preference': frozenset(),
-     'Several_resources': frozenset(['Operator']),
-     'Complex_discourse_unit': frozenset()}
+STAC_EXPECTED_FEATURES = {
+    'EDU': frozenset(['Addressee', 'Surface_act']),
+    'relation': frozenset(['Argument_scope']),
+    'Resource': frozenset(['Status', 'Quantity', 'Correctness', 'Kind']),
+    'Preference': frozenset(),
+    'Several_resources': frozenset(['Operator']),
+    'Complex_discourse_unit': frozenset(),
+    # WIP
+    # TODO enforce invariance of turn features across layers
+    'Turn': frozenset(['Timestamp', 'Identifier', 'Emitter']),
+}
+
+# WIP features that are expected but can be empty
+STAC_OPTIONAL_FEATURES = {
+    'Turn': frozenset(['Developments', 'Resources']),
+}
 
 # lowercase stripped; annotations that are allowed not to have features
 STAC_MISSING_FEATURE_TXT_WHITELIST =\
@@ -94,12 +103,14 @@ def unexpected_features(_, anno):
     not expecting to see in the given annotations
     """
     rty = rough_type(anno)
+    # some fields are optional, others are ignored
+    optional = STAC_OPTIONAL_FEATURES.get(rty, frozenset([]))
     ignored = frozenset(['Comments', 'highlight'])
 
     if rty in STAC_EXPECTED_FEATURES:
         expected = STAC_EXPECTED_FEATURES[rty]
         present = frozenset(anno.features.keys())
-        leftover = present - ignored - expected
+        leftover = present - ignored - optional - expected
         return {k: anno.features[k] for k in leftover}
     else:
         return {}

--- a/educe/stac/sanity/checks/glozz.py
+++ b/educe/stac/sanity/checks/glozz.py
@@ -460,8 +460,8 @@ def run(inputs, k):
             search_glozz_off_by_one(inputs, k))
 
     if k.stage == 'discourse':
-        missing_excess, mismatches =\
-            cross_check_against(inputs, k, stage='units')
+        missing_excess, mismatches = cross_check_against(
+            inputs, k, stage='units')
         squawk('[DISCOURSE v. UNIT] fixed-span items added/deleted/moved',
                missing_excess)
         squawk('[DISCOURSE v. UNIT] id mismatches',

--- a/educe/stac/sanity/main.py
+++ b/educe/stac/sanity/main.py
@@ -22,6 +22,7 @@ import tempfile
 
 from educe import stac
 from educe.corpus import FileId
+import educe.graph
 from educe.stac import graph as egr
 from educe.stac.corpus import (METAL_STR, twin_key)
 from educe.stac.util.args import STAC_GLOBS
@@ -150,7 +151,7 @@ def generate_graphs(settings):
             if gra.get_nodes():
                 with codecs.open(dot_file, 'w', encoding='utf-8') as fout:
                     print(gra.to_string(), file=fout)
-        except egr.DuplicateIdException:
+        except educe.graph.DuplicateIdException:
             warning = ("Couldn't graph %s because it has duplicate "
                        "annotation ids") % dot_file
             print(warning, file=sys.stderr)

--- a/educe/stac/util/cmd/pd_count.py
+++ b/educe/stac/util/cmd/pd_count.py
@@ -352,16 +352,22 @@ def report_on_corpus(corpus):
     edus = dfs['edu']
     dialogues = dfs['dialogue']
     # annotation
-    rels = dfs['rel']
-    disc_rels = rels[rels['stage'] == 'discourse']
+    if 'rels' in dfs:
+        rels = dfs['rel']
+        disc_rels = rels[rels['stage'] == 'discourse']
+    else:
+        disc_rels = pd.DataFrame()
     # pd.util.testing.assert_frame_equal(rels, disc_rels)
     # FIXME this assertion fails for TEST: a document has
     # an "Elaboration" relation in units/SILVER (!?) ; this is
     # probably an error from the annotation process
-    cdus = dfs['cdu']
-    disc_cdus = cdus[cdus['stage'] == 'discourse']
+    if 'cdu' in dfs:
+        cdus = dfs['cdu']
+        disc_cdus = cdus[cdus['stage'] == 'discourse']
+    else:
+        disc_cdus = pd.DataFrame()
     # pd.util.testing.assert_frame_equal(cdus, disc_cdus)
-    # TODO maybe all EDUs from "units" are not acts? should we filter?
+    # TODO maybe filter to keep only the EDUs with a dialogue act annotation?
     acts = edus[edus['stage'] == 'units']
 
     # invariant info
@@ -453,62 +459,69 @@ def report_on_corpus(corpus):
 
     # Dialogue acts
     # =============
-    print(big_banner("Dialogue acts"))
+    if not acts.empty:
+        print(big_banner("Dialogue acts"))
 
-    acts_annot = acts.groupby('annotator')['type']
-    print(acts_annot.count())
-    print()
-    print(acts_annot.value_counts())
-    print()
+        acts_annot = acts.groupby('annotator')['type']
+        print(acts_annot.count())
+        print()
+        print(acts_annot.value_counts())
+        print()
 
     # Links (per annotator)
     # =====================
-    print(big_banner('Links'))
+    if not disc_cdus.empty or not disc_rels.empty:
+        print(big_banner('Links'))
+
     # CDUs
-    print('CDUs: number of members')
-    print('-----------------------')
-    print(disc_cdus['members'].describe().to_frame().unstack().unstack())
-    print(disc_cdus.groupby('annotator')['members'].describe().unstack())
-    print()
+    if not disc_cdus.empty:
+        print('CDUs: number of members')
+        print('-----------------------')
+        print(disc_cdus['members'].describe().to_frame().unstack().unstack())
+        print(disc_cdus.groupby('annotator')['members'].describe().unstack())
+        print()
     # rels
-    print('Relation instances: length (in EDUs)')
-    print('------------------------------------')
-    print(disc_rels['edu_dist'].describe().to_frame().unstack().unstack())
-    print(disc_rels.groupby('annotator')['edu_dist'].describe().unstack())
-    print()
+    if not disc_rels.empty:
+        print('Relation instances: length (in EDUs)')
+        print('------------------------------------')
+        print(disc_rels['edu_dist'].describe().to_frame().unstack().unstack())
+        print(disc_rels.groupby('annotator')['edu_dist'].describe().unstack())
+        print()
 
     # Relation instances
     # ==================
-    print(big_banner("Relation instances"))
+    if not disc_rels.empty:
+        print(big_banner("Relation instances"))
 
-    print('Distribution of relations')
-    print(disc_rels['type'].value_counts())
-    print()
-    print(disc_rels.groupby(['annotator'])['type'].value_counts())
-    print()
-
-    # additional tables
-    print('Relation length (in EDUs)')
-    rel_edist = disc_rels.groupby('type')['edu_dist'].describe().unstack()
-    print(rel_edist.sort_values(by='count', ascending=False))
-    print()
-
-    print('Relation length (in Turn-stars)')
-    rel_tdist = disc_rels.groupby('type')['tstar_dist'].describe().unstack()
-    print(rel_tdist.sort_values(by='count', ascending=False))
-    print()
-
-    print('Type of endpoints')
-    rel_by_endpoints = disc_rels.groupby(['src_type', 'tgt_type'])
-    rel_by_endpoints_stats = rel_by_endpoints['edu_dist'].describe()
-    print(rel_by_endpoints_stats.unstack()['count'].to_frame())
-    print()
-    if False:
-        print('Type of endpoints, by relation')
-        print(rel_by_endpoints['type'].value_counts().to_frame())
+        print('Distribution of relations')
+        print(disc_rels['type'].value_counts())
         print()
+        print(disc_rels.groupby(['annotator'])['type'].value_counts())
+        print()
+
+        # additional tables
+        print('Relation length (in EDUs)')
+        rel_edist = disc_rels.groupby('type')['edu_dist'].describe().unstack()
+        print(rel_edist.sort_values(by='count', ascending=False))
+        print()
+
+        print('Relation length (in Turn-stars)')
+        rel_tdist = disc_rels.groupby('type')['tstar_dist'].describe().unstack()
+        print(rel_tdist.sort_values(by='count', ascending=False))
+        print()
+
+        print('Type of endpoints')
+        rel_by_endpoints = disc_rels.groupby(['src_type', 'tgt_type'])
+        rel_by_endpoints_stats = rel_by_endpoints['edu_dist'].describe()
+        print(rel_by_endpoints_stats.unstack()['count'].to_frame())
+        print()
+        if False:
+            print('Type of endpoints, by relation')
+            print(rel_by_endpoints['type'].value_counts().to_frame())
+            print()
 
     # CDUs
     # ====
-    print(big_banner("CDUs"))
-    print(disc_cdus.describe().transpose())
+    if not disc_cdus.empty:
+        print(big_banner("CDUs"))
+        print(disc_cdus.describe().transpose())

--- a/educe/stac/util/glozz.py
+++ b/educe/stac/util/glozz.py
@@ -9,6 +9,8 @@ STAC Glozz conventions
 # Alternatively the stac module should be kicked out of educe and
 # moved into the stac tree
 
+from __future__ import print_function
+
 import math
 import time
 import random
@@ -123,14 +125,12 @@ def get_turn(tid, doc):
     """
     Return the turn annotation with the desired ID
     """
-    def is_match(anno):
-        "Is a turn with the right turn number"
-        return educe.stac.is_turn(anno) and educe.stac.turn_id(anno) == tid
-
-    turns = list(filter(is_match, doc.annotations()))
+    turns = [anno for anno in doc.annotations()
+             if (educe.stac.is_turn(anno) and
+                 educe.stac.turn_id(anno) == tid)]
     if not turns:
-        raise GlozzException("Turn %d not found" % tid)
+        raise GlozzException("Turn {} not found".format(tid))
     elif len(turns) > 1:
-        raise GlozzException("Found more than one turn with id %d" % tid)
+        raise GlozzException("Found > 1 turn with id {}".format(tid))
     else:
         return turns[0]


### PR DESCRIPTION
This PR refines and makes robust the weaving scripts for the STAC corpus, along with various fixes.

It supports two related kinds of weaving:
* re-injecting lost linguistic messages, in particular spectator messages,
* adding new turns for non-linguistic information, consisting in server messages and changes in the game interface that provide important context for some linguistic interactions.