### PR TITLE
FIX rst_dt.dep2con load RST corpus only when necessary (dirty hack)

### DIFF
--- a/educe/rst_dt/corpus_diagnostics.py
+++ b/educe/rst_dt/corpus_diagnostics.py
@@ -196,6 +196,8 @@ PTB_DIR = os.path.join(os.path.dirname(__file__),
                        '..', '..',
                        'data',  # alt: '..', '..', 'corpora',
                        'PTBIII', 'parsed', 'mrg', 'wsj')
+# FIXME this fails when PTB_DIR does not exist ;
+# I need to find a clean way to address this
 PTB_READER = BracketParseCorpusReader(PTB_DIR,
                                       r'../wsj_.*\.mrg',
                                       encoding='ascii')

--- a/educe/rst_dt/dep2con.py
+++ b/educe/rst_dt/dep2con.py
@@ -12,8 +12,6 @@ from collections import namedtuple
 import itertools
 
 from .annotation import SimpleRSTTree, Node
-from .corpus_diagnostics import (get_most_frequent_unuc,
-                                 load_corpus_as_dataframe)
 from .deptree import RstDtException, NUC_N, NUC_S, NUC_R
 from ..internalutil import treenode
 
@@ -65,6 +63,16 @@ class DummyNuclearityClassifier(object):
             multinuc_lbls.extend(['joint', 'same-unit', 'textual'])
 
         elif self.strategy == "most_frequent_by_rel":
+            # FIXME very dirty hack to avoid loading the RST-DT corpus
+            # upfront (triggered by the import of
+            # load_corpus_as_dataframe)
+            try:
+                from .corpus_diagnostics import (
+                    get_most_frequent_unuc,
+                    load_corpus_as_dataframe
+                )
+            except IOError:
+                raise
             train_df = load_corpus_as_dataframe(selection='train')
             multinuc_lbls.extend(rel_name for rel_name, mode_unuc
                                  in get_most_frequent_unuc(train_df).items()

--- a/educe/stac/oneoff/weave.py
+++ b/educe/stac/oneoff/weave.py
@@ -559,7 +559,7 @@ def stretch_match_many(updates, src_doc, tgt_doc, doc_span_src, doc_span_tgt,
     return updates
 
 
-UNITS = DIALOGUE_ACTS + RENAMES.keys()
+UNITS = DIALOGUE_ACTS + list(RENAMES.keys())
 
 
 def compute_structural_updates(src_doc, tgt_doc, matches, updates, verbose=0):


### PR DESCRIPTION
This PR is a quick n dirty fix to avoid the automatic loading of the RST corpus in dep2con.
The problem comes from the addition of the ctree loss function for training models in attelo, for which I ended up adding imports from educe in attelo (which is very, very wrong).
I need to come up with a more permanent, cleaner solution ASAP.