### PR TITLE
FIX educe.stac declare NonplayerTurn as a variant of Turn

### DIFF
--- a/educe/stac/annotation.py
+++ b/educe/stac/annotation.py
@@ -68,13 +68,16 @@ from educe.annotation import Unit, Relation, Schema
 import educe.glozz as glozz
 
 
-STRUCTURE_TYPES = [
-    'Turn',
+TURN_TYPES = ['Turn', 'NonplayerTurn']
+
+STRUCTURE_TYPES = TURN_TYPES + [
     'Tstar',  # sequence of turns with same speaker
     'paragraph',
     'dialogue', 'Dialogue',  # TODO remove one or keep both?
 ]
+
 RESOURCE_TYPES = ['default', 'Resource']
+
 PREFERENCE_TYPES = ['Preference']
 
 SUBORDINATING_RELATIONS = [
@@ -239,7 +242,7 @@ def is_turn(annotation):
     See Unit typology above
     """
     return (isinstance(annotation, Unit) and
-            annotation.type == 'Turn')
+            annotation.type in TURN_TYPES)
 
 
 def is_paragraph(annotation):


### PR DESCRIPTION
This PR declares `NonplayerTurn` as a variant of `Turn`.

This simple fix seems sufficient to make stac-check run normally on the 3rd generation of the corpus (situated communication).
Let us keep our fingers crossed.