### PR TITLE
ENH+FIX >4x speed-up for alignment of PTB tokens with EDUs, minor fixes

### DIFF
--- a/educe/rst_dt/ptb.py
+++ b/educe/rst_dt/ptb.py
@@ -106,9 +106,11 @@ PTB_WRONG_SENTENCE_SEG = [
 ]
 
 # docs for which the RST-WSJ contains erroneous EDU segmentation that
-# conflicts with the (here) correct sentence segmentation from the PTB
+# conflicts with correct segmentation in the PTB ; this is either
+# sentence segmentation or tokenization
 RST_WRONG_EDU_SEG = [
     'wsj_1123',
+    'wsj_1158',  # tokenization
     'wsj_1373',
     'wsj_2317',
     'wsj_2343',
@@ -117,26 +119,28 @@ RST_WRONG_EDU_SEG = [
 
 # PTB has a (virtual) fullstop after sentence-final abbreviation, eg.
 # he went to the U.S.
-_PTB_EXTRA_FULLSTOPS =\
-    [('06/wsj_0617.mrg', 966),
-     ('06/wsj_0695.mrg', 64),
-     ('07/wsj_0764.mrg', 882),  # aka file1
-     ('11/wsj_1101.mrg', 736),
-     ('11/wsj_1125.mrg', 222),
-     ('13/wsj_1318.mrg', 212),
-     ('13/wsj_1377.mrg', 790),
-     ('13/wsj_1390.mrg', 320),
-     ('19/wsj_1988.mrg', 476),
-     ('23/wsj_2303.mrg', 301),
-     ('23/wsj_2320.mrg', 85),
-     ('23/wsj_2320.mrg', 643),
-     ('23/wsj_2321.mrg', 46),
-     ('23/wsj_2398.mrg', 559)]
+_PTB_EXTRA_FULLSTOPS = [
+    ('06/wsj_0617.mrg', 966),
+    ('06/wsj_0695.mrg', 64),
+    ('07/wsj_0764.mrg', 882),  # aka file1
+    ('11/wsj_1101.mrg', 736),
+    ('11/wsj_1125.mrg', 222),
+    ('13/wsj_1318.mrg', 212),
+    ('13/wsj_1377.mrg', 790),
+    ('13/wsj_1390.mrg', 320),
+    ('19/wsj_1988.mrg', 476),
+    ('23/wsj_2303.mrg', 301),
+    ('23/wsj_2320.mrg', 85),
+    ('23/wsj_2320.mrg', 643),
+    ('23/wsj_2321.mrg', 46),
+    ('23/wsj_2398.mrg', 559)
+]
 
 
 # these specific fileid, token number combinations are skipped or rewritten
 # (prefix, subst)
 _PTB_SUBSTS_OTHER = {
+    # * bad (fileX) files
     # file1
     ('07/wsj_0764.mrg', 981): (None, ""),  # token in PTB missing from RST-WSJ
     ('07/wsj_0764.mrg', 982): (None, ""),  # token in PTB missing from RST-WSJ
@@ -159,19 +163,21 @@ _PTB_SUBSTS_OTHER = {
     ('21/wsj_2172.mrg', 1001): (None, "&amp;"),  # & in PTB, &amp; in RST-WSJ
     ('21/wsj_2172.mrg', 1250): (None, ""),  # token in PTB missing from RST-WSJ
     ('21/wsj_2172.mrg', 1280): (None, ""),  # token in PTB missing from RST-WSJ
-    # regular wsj_ files
+    # * regular (wsj_XXXX.out) files
     ('06/wsj_0675.mrg', 546): ("-", None),  # --
     ('11/wsj_1139.mrg', 582): (">", None),  # insertion
     ('11/wsj_1161.mrg', 845): ("<", None),  # insertion
     ('11/wsj_1171.mrg', 207): (None, "'"),   # backtick
     ('13/wsj_1303.mrg', 388): (None, ""),  # extra full stop
     ('13/wsj_1331.mrg', 930): (None, "`S"),
-    ('13/wsj_1367.mrg', 364): ("--", None),  # insertion
+    ('13/wsj_1367.mrg', 364): ("-- ", None),  # insertion
     ('13/wsj_1377.mrg', 4): (None, "")
 }
 
-_PTB_SUBSTS = dict([(_k, (None, "")) for _k in _PTB_EXTRA_FULLSTOPS] +
-                   list(_PTB_SUBSTS_OTHER.items()))
+_PTB_SUBSTS = dict(
+    [(_k, (None, "")) for _k in _PTB_EXTRA_FULLSTOPS]
+    + list(_PTB_SUBSTS_OTHER.items())
+)
 
 
 def _tweak_token(ptb_name):


### PR DESCRIPTION
This PR contains a reimplementation of the alignment procedure between EDUs from the RST-WSJ corpus and tokens from the PTB.
The big-step semantics is identical but the computational complexity is much lower.
The entire `open_plus` function is 4x faster, hence the speedup is more than 4x for this particular procedure.

It also fixes a minor bug in the manual alignment, plus light refactoring.