### PR TITLE
ENH para info

### DIFF
--- a/educe/ptb/annotation.py
+++ b/educe/ptb/annotation.py
@@ -293,20 +293,12 @@ def syntactic_node_seq(ptree, tokens):
     txt_span = Span(tokens[0].text_span().char_start,
                     tokens[-1].text_span().char_end)
 
-    for tpos in ptree.treepositions():
-        node = ptree[tpos]
-        # skip nodes whose span does not enclose txt_span
-        node_txt_span = node.text_span()
-        if not node_txt_span.encloses(txt_span):
-            continue
-
+    for node in ptree.subtrees(lambda t: t.text_span().encloses(txt_span)):
         # * spanning node
         if node.text_span() == txt_span:
             return [node]
 
         # * otherwise: spanning subsequence of kid nodes
-        if not isinstance(node, Tree):
-            continue
         txt_span_start = txt_span.char_start
         txt_span_end = txt_span.char_end
         kids_start = [x.text_span().char_start for x in node]

--- a/educe/rst_dt/corenlp.py
+++ b/educe/rst_dt/corenlp.py
@@ -165,7 +165,7 @@ class CoreNlpParser(object):
         corenlp_out = read_corenlp_result(doc, reader)
 
         # modify DocumentPlus doc to add tokens
-        doc.tkd_tokens.extend(corenlp_out.tokens)
+        doc.set_tokens(corenlp_out.tokens)
 
         return doc
 
@@ -198,10 +198,6 @@ class CoreNlpParser(object):
                      for ctree_no_gf in ctrees_no_gf]
 
         # store trees in doc
-        doc.tkd_trees.extend(ctrees_no_gf)
-        # store lexical heads in doc
-        doc.lex_heads = []
-        doc.lex_heads.append(None)
-        doc.lex_heads.extend(lex_heads)
+        doc.set_syn_ctrees(ctrees_no_gf, lex_heads=lex_heads)
 
         return doc

--- a/educe/rst_dt/document_plus.py
+++ b/educe/rst_dt/document_plus.py
@@ -400,3 +400,46 @@ class DocumentPlus(object):
         erels = [rels.get(epair, 'UNRELATED')
                  for epair in edu_pairs]
         return erels
+
+    def set_syn_ctrees(self, tkd_trees, lex_heads=None):
+        """Set syntactic constituency trees for this document.
+
+        Parameters
+        ----------
+        tkd_trees: list of nltk.tree.Tree
+            Syntactic constituency trees for this document.
+        lex_heads: list of (TODO: see find_lexical_heads), optional
+            List of lexical heads for each node of each tree.
+        """
+        # extend tkd_trees
+        assert len(self.tkd_trees) == 1  # only lpad
+        self.tkd_trees.extend(tkd_trees)
+        # set lexical heads
+        self.lex_heads = []
+        self.lex_heads.append(None)  # for lpad
+        self.lex_heads.extend(lex_heads)
+        # store tree spans
+        self.trees_beg = np.array([-1]  # left padding (dirty)
+                                  + [x.text_span().char_start
+                                     for x in self.tkd_trees[1:]])
+        self.trees_end = np.array([-1]  # left padding (dirty)
+                                  + [x.text_span().char_end
+                                     for x in self.tkd_trees[1:]])
+
+    def set_tokens(self, tokens):
+        """Set tokens for this document.
+
+        Parameters
+        ----------
+        tokens: list of Token
+            List of tokens for this document.
+        """
+        assert len(self.tkd_tokens) == 1  # only lpad
+        self.tkd_tokens.extend(tokens)
+        # store token spans
+        self.toks_beg = np.array([-1]  # left padding (dirty)
+                                 + [x.text_span().char_start
+                                    for x in self.tkd_tokens[1:]])
+        self.toks_end = np.array([-1]  # left padding (dirty)
+                                 + [x.text_span().char_end
+                                    for x in self.tkd_tokens[1:]])

--- a/educe/rst_dt/document_plus.py
+++ b/educe/rst_dt/document_plus.py
@@ -354,7 +354,6 @@ class DocumentPlus(object):
                       np.array(edu_ends)[tok2edu_begs[diff_idc]])
                 print(np.array(edu_begs)[tok2edu_ends[diff_idc]],
                       np.array(edu_ends)[tok2edu_ends[diff_idc]])
-
         # build the mapping from each EDU to token indices
         edu2tokens_begs = {k: [tok_idx for tok_idx, edu_idx in g]
                            for k, g in itertools.groupby(
@@ -364,8 +363,9 @@ class DocumentPlus(object):
                            for k, g in itertools.groupby(
                                    enumerate(tok2edu_ends),
                                    key=lambda x: x[1])}
-        edu2tokens = [np.union1d(edu2tokens_begs.get(edu_idx, []),
-                                 edu2tokens_ends.get(edu_idx, []))
+        edu2tokens = [np.union1d(
+            edu2tokens_begs.get(edu_idx, np.array([], dtype=np.int)),
+            edu2tokens_ends.get(edu_idx, np.array([], dtype=np.int)))
                       for edu_idx in range(len(edus))]
 
         self.edu2tokens = edu2tokens

--- a/educe/rst_dt/learning/base.py
+++ b/educe/rst_dt/learning/base.py
@@ -6,6 +6,11 @@ from __future__ import print_function
 
 from functools import wraps
 
+import numpy as np
+
+from educe.ptb.annotation import syntactic_node_seq
+from educe.ptb.head_finder import find_edu_head
+
 
 class FeatureExtractionException(Exception):
     """
@@ -154,9 +159,12 @@ class DocumentPlusPreprocessor(object):
 
         Returns
         -------
-        result: list of dict of features
-            Basic list of features for each EDU of the document ; each
-            feature is a couple (basic_feat_name, basic_feat_val).
+        edu_infos: list of dict of features
+            List of basic features for each EDU ; each feature is a
+            couple (basic_feat_name, basic_feat_val).
+        para_infos: list of dict of features
+            List of basic features for each paragraph ; each feature is
+            a couple (basic_feat_name, basic_feat_val).
 
         TODO
         ----
@@ -185,8 +193,83 @@ class DocumentPlusPreprocessor(object):
         idxes_in_para = doc.edu2idx_in_para
         rev_idxes_in_para = doc.edu2rev_idx_in_para
 
-        result = []
+        # paragraphs
+        if paragraphs is None:
+            para_infos = None
+        else:
+            para_infos = []
 
+            # special case for the left padding paragraph
+            pfeats = dict()
+            pfeats['tokens'] = [tokens[0]]  # left padding token
+            pfeats['syn_nodes'] = None
+            para_infos.append(pfeats)
+
+            # regular paragraphs
+            for para_idx, para in enumerate(paragraphs[1:], start=1):
+                pfeats = dict()
+                para_beg = para.sentences[0].span.char_start
+                para_end = para.sentences[-1].span.char_end
+                trees_beg = doc.trees_beg
+                trees_end = doc.trees_end
+                toks_beg = doc.toks_beg
+                toks_end = doc.toks_end
+
+                # * token characterization of the paragraph
+                encltoks_idc = np.where(
+                    np.logical_and(toks_beg >= para_beg,
+                                   toks_end <= para_end)
+                )[0]
+                encltoks = [tokens[i] for i in encltoks_idc]
+                pfeats['tokens'] = encltoks
+
+                # * syntactic characterization of the paragraph
+                # find the syntactic trees that span this paragraph
+                enclosed_idc = np.intersect1d(
+                    np.where(trees_beg >= para_beg),
+                    np.where(trees_end <= para_end))
+                overlapd_idc = np.intersect1d(
+                    np.where(trees_beg < para_end),
+                    np.where(trees_end > para_beg))
+                if np.array_equal(enclosed_idc, overlapd_idc):
+                    # sentence seg and paragraph seg are compatible
+                    syn_nodes = [trees[tree_idx]
+                                 for tree_idx in overlapd_idc]
+                else:
+                    # mismatch between the sentence segmentation from the
+                    # PTB and paragraph segmentation from the RST-WSJ
+                    strad_idc = np.setdiff1d(overlapd_idc, enclosed_idc)
+                    syn_nodes = []
+                    for tree_idx in overlapd_idc:
+                        syn_tree = trees[tree_idx]
+                        if tree_idx not in strad_idc:
+                            syn_nodes.append(syn_tree)
+                            continue
+                        # find the list of tokens that overlap this
+                        # paragraph, and belong to this straddling
+                        # tree
+                        tree_beg = trees_beg[tree_idx]
+                        tree_end = trees_end[tree_idx]
+                        # here, reduce(np.logical_and(...)) was 2x
+                        # faster than np.logical_and.reduce(...)
+                        overtoks_idc = np.where(
+                            reduce(np.logical_and,
+                                   (toks_beg < para_end,
+                                    toks_end > para_beg,
+                                    toks_beg >= tree_beg,
+                                    toks_end <= tree_end)
+                            )
+                        )[0]
+                        overtoks = [tokens[i] for i in overtoks_idc]
+                        syn_node_seq = syntactic_node_seq(
+                            syn_tree, overtoks)
+                        syn_nodes.extend(syn_node_seq)
+                # add basic feature
+                pfeats['syn_nodes'] = syn_nodes
+                # store
+                para_infos.append(pfeats)
+        # EDUs
+        edu_infos = []
         # special case: left padding EDU
         edu = edus[0]
         res = dict()
@@ -215,7 +298,7 @@ class DocumentPlusPreprocessor(object):
                                else None)  # NEW
         # raw sent
         res['raw_sent_idx'] = edu2raw_sent[0]
-        result.append(res)
+        edu_infos.append(res)
 
         # regular EDUs
         for edu_idx, edu in enumerate(edus[1:], start=1):
@@ -223,7 +306,7 @@ class DocumentPlusPreprocessor(object):
             res['edu'] = edu
 
             # raw words (temporary)
-            res['raw_words'] = raw_words[edu]
+            res['raw_words'] = raw_words[edu_idx]
 
             # tokens
             if tokens is not None:
@@ -286,6 +369,20 @@ class DocumentPlusPreprocessor(object):
             if len(trees) > 1:
                 tree_idx = edu2sent[edu_idx]
                 res['tkd_tree_idx'] = tree_idx
-            result.append(res)
+                if tree_idx is not None:
+                    # head node of the EDU (for DS-LST features)
+                    ptree = trees[tree_idx]
+                    pheads = lex_heads[tree_idx]
+                    # tree positions (in the syn tree) of the words of
+                    # the EDU
+                    tpos_leaves_edu = [x for x
+                                       in ptree.treepositions('leaves')
+                                       if ptree[x].overlaps(edu)]
+                    tpos_words = set(tpos_leaves_edu)
+                    res['tpos_words'] = tpos_words
+                    edu_head = find_edu_head(ptree, pheads, tpos_words)
+                    res['edu_head'] = edu_head
 
-        return result
+            edu_infos.append(res)
+
+        return edu_infos, para_infos

--- a/educe/rst_dt/learning/doc_vectorizer.py
+++ b/educe/rst_dt/learning/doc_vectorizer.py
@@ -248,8 +248,9 @@ class DocumentCountVectorizer(object):
         split_feat_space = self.split_feat_space
         # end NEW
 
+        edu2para = doc.edu2para
         # preprocess each EDU
-        edu_infos = doc_preprocess(doc)
+        edu_infos, para_infos = doc_preprocess(doc)
 
         # extract one feature vector per EDU pair
         feat_vecs = []
@@ -273,15 +274,26 @@ class DocumentCountVectorizer(object):
             # retrieve info for each EDU
             edu_info1 = edu_infos[edu1.num]
             edu_info2 = edu_infos[edu2.num]
+            # NEW paragraph info
+            try:
+                para_info1 = para_infos[edu2para[edu1.num]]
+            except TypeError:
+                para_info1 = None
+            try:
+                para_info2 = para_infos[edu2para[edu2.num]]
+            except TypeError:
+                para_info2 = None
             # ... and for the EDUs in between (WIP interval)
             edu_info_bwn = [edu_infos[x] for x in bwn_nums]
             # gov EDU
             if edu1.num not in sf_cache:
-                sf_cache[edu1.num] = dict(sing_extract(doc, edu_info1))
+                sf_cache[edu1.num] = dict(sing_extract(
+                    doc, edu_info1, para_info1))
             feat_dict['EDU1'] = dict(sf_cache[edu1.num])
             # dep EDU
             if edu2.num not in sf_cache:
-                sf_cache[edu2.num] = dict(sing_extract(doc, edu_info2))
+                sf_cache[edu2.num] = dict(sing_extract(
+                    doc, edu_info2, para_info2))
             feat_dict['EDU2'] = dict(sf_cache[edu2.num])
             # pair + in between
             feat_dict['pair'] = dict(pair_extract(

--- a/educe/rst_dt/learning/features.py
+++ b/educe/rst_dt/learning/features.py
@@ -26,7 +26,7 @@ SINGLE_RAW_WORD = [
 ]
 
 
-def extract_single_raw_word(doc, edu_info):
+def extract_single_raw_word(doc, edu_info, para_info):
     """raw word features for the EDU"""
     raw_words = edu_info['raw_words']
     if raw_words:
@@ -49,7 +49,7 @@ SINGLE_PTB_TOKEN_WORD = [
 ]
 
 
-def extract_single_ptb_token_word(doc, edu_info):
+def extract_single_ptb_token_word(doc, edu_info, para_info):
     """word features on PTB tokens for the EDU"""
     try:
         words = edu_info['words']
@@ -73,7 +73,7 @@ SINGLE_PTB_TOKEN_POS = [
 ]
 
 
-def extract_single_ptb_token_pos(doc, edu_info):
+def extract_single_ptb_token_pos(doc, edu_info, para_info):
     """POS features on PTB tokens for the EDU"""
     try:
         tags = edu_info['tags']
@@ -100,11 +100,11 @@ def build_edu_feature_extractor():
     # PTB pos
     funcs.append(extract_single_ptb_token_pos)
 
-    def _extract_all(doc, edu_info):
+    def _extract_all(doc, edu_info, para_info):
         """inner helper because I am lost at sea here"""
         # TODO do this in a cleaner manner
         for fct in funcs:
-            for feat in fct(doc, edu_info):
+            for feat in fct(doc, edu_info, para_info):
                 yield feat
 
     # extractor

--- a/educe/rst_dt/learning/features_dev.py
+++ b/educe/rst_dt/learning/features_dev.py
@@ -267,7 +267,7 @@ def extract_single_para(doc, edu_info, para_info):
         if para_rev_idx is not None:
             yield ('paragraph_rev_id', para_rev_idx)
     # features on the surrounding paragraph
-    if True:
+    if False:
         # WIP as of 2016-06-10
         paras = doc.paragraphs
         if paras is not None and para_idx is not None:

--- a/educe/rst_dt/learning/features_li2014.py
+++ b/educe/rst_dt/learning/features_li2014.py
@@ -52,7 +52,7 @@ SINGLE_WORD = [
 ]
 
 
-def extract_single_word(doc, edu_info):
+def extract_single_word(doc, edu_info, para_info):
     """word features for the EDU"""
     try:
         words = edu_info['words']
@@ -75,7 +75,7 @@ SINGLE_POS = [
 ]
 
 
-def extract_single_pos(doc, edu_info):
+def extract_single_pos(doc, edu_info, para_info):
     """POS features for the EDU"""
     try:
         tags = edu_info['tags']
@@ -97,7 +97,7 @@ SINGLE_LENGTH = [
 ]
 
 
-def extract_single_length(doc, edu_info):
+def extract_single_length(doc, edu_info, para_info):
     """Sentence features for the EDU"""
     try:
         words = edu_info['words']
@@ -122,7 +122,7 @@ SINGLE_SENTENCE = [
 ]
 
 
-def extract_single_sentence(doc, edu_info):
+def extract_single_sentence(doc, edu_info, para_info):
     """Sentence features for the EDU"""
     try:
         offset = edu_info['edu_idx_in_sent']
@@ -152,7 +152,7 @@ SINGLE_PARA = [
 ]
 
 
-def extract_single_para(doc, edu_info):
+def extract_single_para(doc, edu_info, para_info):
     """paragraph features for the EDU"""
     try:
         para_idx = edu_info['para_idx']
@@ -209,7 +209,7 @@ SINGLE_SYNTAX = [
 ]
 
 
-def extract_single_syntax(doc, edu_info):
+def extract_single_syntax(doc, edu_info, para_info):
     """syntactic features for the EDU"""
     syn_labels = get_syntactic_labels(doc, edu_info)
     if syn_labels is not None:
@@ -237,11 +237,11 @@ def build_edu_feature_extractor():
     # syntax (disabled)
     # funcs.append(extract_single_syntax)
 
-    def _extract_all(doc, edu_info):
+    def _extract_all(doc, edu_info, para_info):
         """inner helper because I am lost at sea here"""
         # TODO do this in a cleaner manner
         for fct in funcs:
-            for feat in fct(doc, edu_info):
+            for feat in fct(doc, edu_info, para_info):
                 yield feat
 
     # extractor

--- a/educe/rst_dt/ptb.py
+++ b/educe/rst_dt/ptb.py
@@ -239,7 +239,15 @@ class PtbParser(object):
     def tokenize(self, doc):
         """Tokenize the document text using the PTB gold annotation.
 
-        Return a tokenized document.
+        Parameters
+        ----------
+        doc: DocumentPlus
+            Rich representation of the document.
+
+        Returns
+        -------
+        doc: DocumentPlus
+            Rich representation of the document, with tokenization.
         """
         # get tokens from PTB
         ptb_name = _guess_ptb_name(doc.key)
@@ -266,7 +274,8 @@ class PtbParser(object):
         return doc
 
     def parse(self, doc):
-        """
+        """Parse a document, using the gold PTB annotation.
+
         Given a document, return a list of educified PTB parse trees
         (one per sentence).
 
@@ -275,6 +284,17 @@ class PtbParser(object):
         associated with a span within the RST DT text.
 
         Note: does nothing if there is no associated PTB corpus entry.
+
+        Parameters
+        ----------
+        doc: DocumentPlus
+            Rich representation of the document.
+
+        Returns
+        -------
+        doc: DocumentPlus
+            Rich representation of the document, with syntactic
+            constituency trees.
         """
         # get PTB trees
         ptb_name = _guess_ptb_name(doc.key)

--- a/educe/rst_dt/ptb.py
+++ b/educe/rst_dt/ptb.py
@@ -165,7 +165,7 @@ _PTB_SUBSTS_OTHER = {
     ('21/wsj_2172.mrg', 1280): (None, ""),  # token in PTB missing from RST-WSJ
     # * regular (wsj_XXXX.out) files
     ('06/wsj_0675.mrg', 546): ("-", None),  # --
-    ('11/wsj_1139.mrg', 582): (">", None),  # insertion
+    ('11/wsj_1139.mrg', 582): ("> ", None),  # insertion
     ('11/wsj_1161.mrg', 845): ("<", None),  # insertion
     ('11/wsj_1171.mrg', 207): (None, "'"),   # backtick
     ('13/wsj_1303.mrg', 388): (None, ""),  # extra full stop
@@ -261,7 +261,7 @@ class PtbParser(object):
         result = [_mk_token(t, s) for t, s in izip(tweaked2, spans)]
 
         # store in doc
-        doc.tkd_tokens.extend(result)
+        doc.set_tokens(result)
 
         return doc
 
@@ -309,13 +309,7 @@ class PtbParser(object):
             lex_heads.append(lheads)
 
         # store trees in doc
-        doc.tkd_trees.extend(trees)
-        # store lexical heads in doc
-        # TODO move to DocumentPlus
-        doc.lex_heads = []
-        doc.lex_heads.append(None)
-        # end TODO
-        doc.lex_heads.extend(lex_heads)
+        doc.set_syn_ctrees(trees, lex_heads=lex_heads)
 
         return doc
 
@@ -346,6 +340,10 @@ def align_edus_with_sentences(edus, syn_trees, strict=False):
     -------
     edu2sent: list(int or None)
         Map from EDU to (0-based) sentence index or None.
+
+    TODO
+    ----
+    * [ ] rewrite a faster version using numpy
     """
     edu2sent = []
     for edu in edus:


### PR DESCRIPTION
This PR contains a handful of fixes and optimization, plus minor improvements in documentation.

Optimizations and fixes are due to the use of more appropriate NLTK functions, and the wider adoption of numpy (for example to compute the alignment between EDUs and paragraphs).
This PR also introduces paragraph-wide syntactic features. These are currently disabled as they resulted in a major increase of the size of the vocabulary without any gain in parsing experiments.
We'll see how we can adjust and fine-tune them in the near future.

This PR also fixes a discrepancy between constituency trees from the PTB and those output by the CoreNLP parser: PTB trees are delimited by a pair of non-labelled parentheses (automatically deleted by NLTK), whereas the corresponding parentheses in the CoreNLP output are labelled 'ROOT'.
We fix this discrepancy by skipping the 'ROOT' parentheses in CoreNLP output.