### PR TITLE
FIX stac-edit move: initial, final whitespaces

### DIFF
--- a/educe/stac/edit/cmd/move.py
+++ b/educe/stac/edit/cmd/move.py
@@ -98,36 +98,45 @@ def main(args):
     tgt_corpus = read_target_corpus(args)
 
     renames = compute_renames(tgt_corpus, src_corpus)
-    for src_k in src_corpus:
+
+    for src_k, src_doc in src_corpus.items():
+        # retrieve target subdoc
         tgt_k = copy.copy(src_k)
         tgt_k.subdoc = args.target
         print(src_k, tgt_k, file=sys.stderr)
         if tgt_k not in tgt_corpus:
-            sys.exit("Uh-oh! we don't have %s in the corpus" % tgt_k)
+            raise ValueError("Uh-oh! we don't have %s in the corpus" % tgt_k)
+        tgt_doc = tgt_corpus[tgt_k]
+        # move portion from source to target subdoc
+        if start == 0:
+            # move up
+            new_src_doc, new_tgt_doc = move_portion(
+                renames, src_doc, tgt_doc,
+                end,  # src_split
+                tgt_split=-1)
+        elif end == src_doc.text_span().char_end:
+            # move down
+            # move_portion inserts src_doc[0:src_split] between
+            # tgt_doc[0:tgt_split] and tgt_doc[tgt_split:],
+            # so we detach src_doc[start:] into a temporary doc,
+            # then call move_portion on this temporary doc
+            new_src_doc, src_doc2 = split_doc(src_doc, start)
+            _, new_tgt_doc = move_portion(
+                renames, src_doc2, tgt_doc,
+                -1,  # src_split
+                tgt_split=0)
         else:
-            src_doc = src_corpus[src_k]
-            tgt_doc = tgt_corpus[tgt_k]
-            if start == 0:
-                new_src_doc, new_tgt_doc =\
-                    move_portion(renames, src_doc, tgt_doc,
-                                 src_split=end,
-                                 tgt_split=-1)
-            elif end == src_doc.text_span().char_end:
-                new_src_doc, src_doc2 = split_doc(src_doc, start)
-                _, new_tgt_doc =\
-                    move_portion(renames, src_doc2, tgt_doc,
-                                 src_split=-1,
-                                 tgt_split=0)
-            else:
-                sys.exit("Sorry, can only move to the start or to the "
-                         "end of a document at the moment")
-            diffs = ["======= TO %s   ========" % tgt_k,
-                     show_diff(tgt_doc, new_tgt_doc),
-                     "^------ FROM %s" % src_k,
-                     show_diff(src_doc, new_src_doc),
-                     ""]
-            print("\n".join(diffs), file=sys.stderr)
-            save_document(output_dir, src_k, new_src_doc)
-            save_document(output_dir, tgt_k, new_tgt_doc)
+            raise ValueError("Sorry, can only move to the start or to the "
+                             "end of a document at the moment")
+        # print diff for suggested commit message
+        diffs = ["======= TO %s   ========" % tgt_k,
+                 show_diff(tgt_doc, new_tgt_doc),
+                 "^------ FROM %s" % src_k,
+                 show_diff(src_doc, new_src_doc),
+                 ""]
+        print("\n".join(diffs), file=sys.stderr)
+        # dump the modified documents
+        save_document(output_dir, src_k, new_src_doc)
+        save_document(output_dir, tgt_k, new_tgt_doc)
 
     announce_output_dir(output_dir)

--- a/educe/stac/edit/cmd/move.py
+++ b/educe/stac/edit/cmd/move.py
@@ -19,7 +19,7 @@ from educe.stac.util.args import\
      comma_span,
      get_output_dir, announce_output_dir)
 from educe.stac.util.doc import\
-    (compute_renames, move_portion, split_doc)
+    (compute_renames, evil_set_text, move_portion, split_doc)
 from educe.stac.util.output import save_document
 
 
@@ -125,6 +125,9 @@ def main(args):
                 renames, src_doc2, tgt_doc,
                 -1,  # src_split
                 tgt_split=0)
+            # the whitespace between new_src_doc and src_doc2 went to
+            # src_doc2, so we need to append a new whitespace to new_src_doc
+            evil_set_text(new_src_doc, new_src_doc.text() + ' ')
         else:
             raise ValueError("Sorry, can only move to the start or to the "
                              "end of a document at the moment")

--- a/educe/stac/util/doc.py
+++ b/educe/stac/util/doc.py
@@ -122,10 +122,9 @@ def shift_annotations(doc, offset, point=None):
 
     def shift(anno):
         "Shift a single annotation"
-        anno2 = copy.deepcopy(anno)
         if offset != 0 and isinstance(anno, Unit) and is_moveable(anno):
-            anno2.span = anno.span.shift(offset)
-        return anno2
+            anno.span = anno.span.shift(offset)
+        return anno
 
     if offset > 0:
         padding = " " * offset
@@ -133,11 +132,11 @@ def shift_annotations(doc, offset, point=None):
     else:
         start = 0 - offset
         txt2 = doc.text()[start:]
-    doc2 = copy.copy(doc)
+    doc2 = copy.deepcopy(doc)
     evil_set_text(doc2, txt2)
-    doc2.units = [shift(x) for x in doc.units]
-    doc2.schemas = [shift(x) for x in doc.schemas]
-    doc2.relations = [shift(x) for x in doc.relations]
+    doc2.units = [shift(x) for x in doc2.units]
+    doc2.schemas = [shift(x) for x in doc2.schemas]
+    doc2.relations = [shift(x) for x in doc2.relations]
     return doc2
 
 
@@ -183,15 +182,15 @@ def narrow_to_span(doc, span):
     annotations that are within the span specified by portion.
     """
     def slice_annos(annos):
-        "Return a copy of all annotations within a span"
-        return [copy.copy(anno) for anno in annos
-                if span.encloses(anno.text_span())]
+        "Select annotations within a span"
+        return [x for x in annos if span.encloses(x.text_span())]
 
     offset = 0 - span.char_start
-    doc2 = copy.copy(doc)
-    doc2.units = slice_annos(doc.units)
-    doc2.schemas = slice_annos(doc.schemas)
-    doc2.relations = slice_annos(doc.relations)
+    doc2 = copy.deepcopy(doc)
+    doc2.units = slice_annos(doc2.units)
+    doc2.schemas = slice_annos(doc2.schemas)
+    doc2.relations = slice_annos(doc2.relations)
+    # NB: shift_annotations() does a deepcopy too
     doc2 = shift_annotations(doc2, offset)
     evil_set_text(doc2, doc.text()[span.char_start:span.char_end])
     return doc2

--- a/educe/stac/util/doc.py
+++ b/educe/stac/util/doc.py
@@ -9,7 +9,6 @@ to another
 
 from __future__ import print_function
 from collections import defaultdict
-from itertools import chain
 import copy
 
 from educe.annotation import Unit, Span
@@ -253,7 +252,9 @@ def split_doc(doc, middle):
 
     prefix = Span(0, middle)
     suffix = Span(middle, doc_len)
-    return narrow_to_span(doc, prefix), narrow_to_span(doc, suffix)
+    doc_prefix = narrow_to_span(doc, prefix)
+    doc_suffix = narrow_to_span(doc, suffix)
+    return doc_prefix, doc_suffix
 
 
 def rename_ids(renames, doc):
@@ -295,9 +296,10 @@ def rename_ids(renames, doc):
 def move_portion(renames, src_doc, tgt_doc,
                  src_split,
                  tgt_split=-1):
-    """
-    Return a copy of the documents such that part of the source
-    document has been moved into the target document.
+    """Move part of the source document into the target document.
+
+    This returns an updated copy of both the source and target
+    documents.
 
     This can capture a couple of patterns:
 
@@ -358,6 +360,7 @@ def move_portion(renames, src_doc, tgt_doc,
     if not src_text[0] == ' ':
         oops = "Source text does not start with a space\n" +\
                 snippet(src_text, 0)
+        raise StacDocException(oops)
     if not src_text[src_split] == ' ':
         oops = "Source text does not have a space at its split point\n" +\
                snippet(src_text, src_split)

--- a/educe/stac/util/doc.py
+++ b/educe/stac/util/doc.py
@@ -220,9 +220,9 @@ def split_doc(doc, middle):
         Deep copy of `doc` restricted to span [middle:] ; the span of each
         annotation is shifted to match the new text.
     """
-    doc_len = doc.text_span().char_end
+    doc_len = len(doc.text())
     if middle < 0:
-        middle = doc_len + 1 + middle
+        middle = doc_len + middle
 
     def straddles(point, span):
         """


### PR DESCRIPTION
This PR fixes a long-standing bug in the `stac-edit move` command, which was not redistributing whitespaces correctly between the source document and the insertion site in the target document.

For instance, moving text down resulted in no final whitespace in the source document and two whitespaces between the inserted material and the insertion site in the target document.
This prevented certain subsequent operations, like moving (part of the) text back to its original document.

The solution proposed in this PR fixes several functions in `stac.util.doc` that appeared to be slightly broken: `shift_annotations`, `narrow_to_span` and `split_doc`.

This PR replaces the quick fix proposed in irit-melodi/educe#104.