### PR TITLE
FIX+ENH fix stac-oneoff delete-text, new stac-oneoff clean-whitespaces

### DIFF
--- a/educe/stac/oneoff/cmd/__init__.py
+++ b/educe/stac/oneoff/cmd/__init__.py
@@ -10,6 +10,7 @@ stac-oneoff subcommands
 from . import (clean_emoticons,
                clean_schemas,
                clean_dialogue_acts,
+               clean_whitespaces,
                delete_text,
                replace_text,
                weave)
@@ -22,6 +23,7 @@ SUBCOMMAND_SECTIONS = [
     ('Cleanups',
      [clean_emoticons,
       clean_schemas,
+      clean_whitespaces,
       clean_dialogue_acts]),
     ('Invasive',
      [weave,

--- a/educe/stac/oneoff/cmd/clean_whitespaces.py
+++ b/educe/stac/oneoff/cmd/clean_whitespaces.py
@@ -1,0 +1,88 @@
+"""Fix whitespaces in the glozz .ac files.
+
+This script currently adds missing initial and final whitespaces in
+glozz .ac files and ensures that neither is covered by an annotation.
+
+In the near future, it should also delete excess whitespaces in the middle
+of the text that were created by buggy versions of `stac-edit move`.
+"""
+
+from __future__ import print_function
+
+from educe.annotation import Span
+from educe.stac.util.args import (add_usual_output_args,
+                                  announce_output_dir,
+                                  get_output_dir,
+                                  read_corpus)
+from educe.stac.util.doc import (delete_text_at_span,
+                                 evil_set_text,
+                                 shift_annotations)
+from educe.stac.util.output import save_document
+
+NAME = 'clean-whitespaces'
+
+
+def config_argparser(parser):
+    """Subcommand flags.
+
+    You should create and pass in the subparser to which the flags are
+    to be added.
+    """
+    parser.add_argument('corpus', metavar='DIR',
+                        nargs='?',
+                        help='corpus dir')
+    add_usual_output_args(parser, default_overwrite=True)
+    parser.set_defaults(func=main)
+
+
+def fix_surrounding_whitespaces(doc):
+    """Ensure that a document text starts and ends with a whitespace.
+
+    This checks for a leading and trailing whitespace and fixes them
+    if necessary.
+    The leading and trailing whitespaces are restored such that they
+    do not belong to any annotation.
+
+    This is still work-in-progress.
+
+    Parameters
+    ----------
+    doc: Document
+        Original document
+
+    Returns
+    -------
+    doc: Document
+        Updated document
+    """
+    # ensure there is exactly one leading whitespace:
+    # remove all present, prepend exactly one
+    sp_left = len(doc.text()) - len(doc.text().lstrip())
+    if sp_left:
+        doc, _ = delete_text_at_span(doc, Span(0, sp_left))
+    doc = shift_annotations(doc, 1)
+
+    # ensure there is exactly one trailing whitespace:
+    # remove all present, append exactly one
+    doc_txt_len = len(doc.text())
+    sp_right = len(doc.text()) - len(doc.text().rstrip())
+    if sp_right:
+        doc, _ = delete_text_at_span(doc, Span(doc_txt_len - sp_right,
+                                               doc_txt_len))
+    evil_set_text(doc, doc.text() + ' ')
+
+    return doc
+
+
+def main(args):
+    """Subcommand main.
+
+    You shouldn't need to call this yourself if you're using
+    `config_argparser`.
+    """
+    corpus = read_corpus(args)
+    output_dir = get_output_dir(args, default_overwrite=True)
+    for k, doc in corpus.items():
+        doc = fix_surrounding_whitespaces(doc)
+        save_document(output_dir, k, doc)
+    announce_output_dir(output_dir)

--- a/educe/stac/oneoff/cmd/delete_text.py
+++ b/educe/stac/oneoff/cmd/delete_text.py
@@ -3,12 +3,9 @@
 """
 
 from __future__ import print_function
-import copy
 import sys
 
-from educe.annotation import Span, Unit
 import educe.stac
-from educe.stac.annotation import is_turn
 from educe.stac.edit.cmd.move import is_requested
 from educe.stac.util.annotate import annotate_doc, show_diff
 from educe.stac.util.args import (add_commit_args,
@@ -17,102 +14,11 @@ from educe.stac.util.args import (add_commit_args,
                                   announce_output_dir,
                                   comma_span,
                                   get_output_dir)
-from educe.stac.util.doc import evil_set_text
+from educe.stac.util.doc import delete_text_at_span
 from educe.stac.util.output import save_document
 
 
 NAME = 'delete-text'
-
-
-def delete_text_at_span(doc, span, minor=True):
-    """Delete text at `span` in `doc`.
-
-    Parameters
-    ----------
-    doc : Document
-        Original document
-    span : Span
-        Span of the substitution site
-    minor : boolean, default True
-        If True, the text deletion is considered minor and annotations
-        are kept as they are (with shifted spans) ; otherwise unit
-        annotations and discourse relations are deleted.
-
-    Returns
-    -------
-    doc2 : Document
-        Updated document
-    del_annos : set of Annotation
-        Deleted annotations
-    """
-    def shift_anno(anno, offset, point):
-        """Get a shifted copy of an annotation"""
-        anno2 = copy.deepcopy(anno)
-        if not isinstance(anno, Unit):
-            return anno2
-
-        anno_span = anno2.text_span()
-        if anno_span.char_start >= point:
-            # if the annotation is entirely after the deletion site,
-            # shift the whole span
-            anno2.span = anno_span.shift(offset)
-        elif anno_span.char_end >= point:
-            # if the annotation straddles the substitution site,
-            # stretch (shift its end)
-            anno2.span = Span(anno_span.char_start,
-                              anno_span.char_end + offset)
-        return anno2
-
-    # compute text update
-    old_txt = doc.text()
-    new_txt = old_txt[:span.char_start] + old_txt[span.char_end:]
-    offset = len(new_txt) - len(old_txt)
-    point = span.char_end
-    # create a copy of the doc
-    doc2 = copy.copy(doc)
-    evil_set_text(doc2, new_txt)
-    # shift or stretch all units
-    # if not minor, skip annotations in the subsitution site so that
-    # they get lost
-    if minor:
-        doc2.units = [shift_anno(x, offset, point)
-                      for x in doc.units]
-        doc2.schemas = [shift_anno(x, offset, point)
-                        for x in doc.schemas]
-        doc2.relations = [shift_anno(x, offset, point)
-                          for x in doc.relations]
-    else:
-        deleted_units = set(x for x in doc.units
-                            if span.encloses(x.text_span()))
-        # fixed point deletion of schemas and relations
-        deleted_schms = set(x for x in doc.schemas
-                            if any(y in deleted_units for y in x.members))
-        deleted_rels = set(x for x in doc.relations
-                           if (x.source in deleted_units or
-                               x.target in deleted_units))
-        new_del_schms = deleted_schms
-        new_del_rels = deleted_rels
-        while new_del_schms or new_del_rels:
-            next_del_schms = set(x for x in doc.schemas
-                                 if any(y in new_del_schms
-                                        for y in x.members))
-            next_del_rels = set(x for x in doc.relations
-                                if (x.source in new_del_rels or
-                                    x.target in new_del_rels))
-            deleted_schms.update(next_del_schms)
-            deleted_rels.update(next_del_rels)
-            new_del_schms = next_del_schms
-            new_del_rels = next_del_rels
-        # shift everything we keep
-        doc2.units = [shift_anno(x, offset, point) for x in doc.units
-                      if x not in deleted_units]
-        doc2.schemas = [shift_anno(x, offset, point) for x in doc.schemas
-                        if x not in deleted_schms]
-        doc2.relations = [shift_anno(x, offset, point) for x in doc.relations
-                          if x not in deleted_rels]
-    # TODO print deleted_units, deleted_rels, deleted_schms
-    del_annos = (deleted_units, deleted_schms, deleted_rels)
-    return doc2, del_annos
 
 
 def commit_msg(key, anno_str_before, all_del_annos):


### PR DESCRIPTION
This PR fixes `stac-oneoff delete-text` and introduces a new command: `stac-oneoff clean-whitespaces`.
The latter is still work-in-progress as I am not 100% sure of what its effect should really be.
For example, should the initial whitespace belong to the first dialogue or not? Is there code in the educe/stac codebase that depends on such an inclusion?
