### PR TITLE
ENH sort labels in LabelVectorizer for STAC

### DIFF
--- a/educe/stac/learning/doc_vectorizer.py
+++ b/educe/stac/learning/doc_vectorizer.py
@@ -2,6 +2,8 @@
 
 # pylint: disable=too-few-public-methods
 
+from collections import Sequence
+
 from .features import clean_dialogue_act
 
 
@@ -40,11 +42,26 @@ class LabelVectorizer(object):
 
     def __init__(self, instance_generator, labels, zero=False):
         """
-        instance_generator to enumerate the instances from a doc
 
-        :type labels: set(string)
+        Parameters
+        ----------
+        instance_generator : function that enumerates instances from doc
+            Function that given a ? enumerates its candidate instances.
+
+        labels : iterable of string
+            Set of domain labels. If it is provided as a sequence, the
+            order of labels is preserved ; otherwise its elements are
+            sorted before storage. This guarantees a stable behaviour
+            across runs and platforms, which greatly facilitates
+            the comparability of models and results.
+
+        zero : boolean, defaults to False
+            If True, transform() will return the unknown label (UNK) for
+            all (MM or only unrelated?) pairs.
         """
         self.instance_generator = instance_generator
+        if not isinstance(labels, Sequence):
+            labels = sorted(labels)
         self.labelset_ = {l: i for i, l in enumerate(labels, start=3)}
         self.labelset_[UNK] = 0
         self.labelset_[ROOT] = 1


### PR DESCRIPTION
This PR makes the STAC LabelVectorizer sort relation labels before storing them.
The enumeration order of relations is now guaranteed to be stable across runs and platforms.

Minor variations in scores result from this change, due to the difficulty to predict or distinguish certain relations.