### PR TITLE
ENH proper type for TurnId in STAC

### DIFF
--- a/educe/stac/annotation.py
+++ b/educe/stac/annotation.py
@@ -137,15 +137,48 @@ def split_turn_text(text):
                         text)
 
 
-def parse_turn_id(turn_id_str):
-    """Parse a turn identifier akin to a Gorn address from a string."""
-    return tuple(int(x) for x in turn_id_str.split('.'))
+class TurnId(tuple):
+    """Turn identifier akin to a Gorn address.
+
+    A Gorn address is a tuple of integers.
+    """
+
+    def __new__(cls, seq_int):
+        """Create a TurnId from a sequence of integers."""
+        return super(TurnId, cls).__new__(cls, tuple(seq_int))
+
+    def __str__(self):
+        """Custom string representation as dot-separated integers.
+
+        ex: (21.0.1)
+        """
+        return '.'.join(str(x) for x in self)
+
+    @classmethod
+    def from_string(cls, tid_str):
+        """Create a TurnId from a string.
+
+        ex: (21.0.1)
+        """
+        return cls(int(x) for x in tid_str.split('.'))
 
 
 def turn_id(anno):
-    """Get the turn identifier for a turn annotation (or None)."""
+    """Get the turn identifier for a turn annotation (or None).
+
+    Parameters
+    ----------
+    anno : Annotation
+        Annotation
+
+    Returns
+    -------
+    turn_id : tuple(int) or None
+        Turn identifier ; None if the annotation has no feature
+        'Identifier'.
+    """
     tid_str = anno.features.get('Identifier')
-    return parse_turn_id(tid_str) if tid_str is not None else None
+    return TurnId.from_string(tid_str) if tid_str is not None else None
 
 
 def addressees(anno):

--- a/educe/stac/edit/cmd/merge_dialogue.py
+++ b/educe/stac/edit/cmd/merge_dialogue.py
@@ -12,7 +12,7 @@ import sys
 from educe.annotation import Span
 from educe.glozz import GlozzException
 
-from educe.stac.annotation import parse_turn_id
+from educe.stac.annotation import TurnId
 from educe.stac.util.annotate import annotate_doc
 from educe.stac.util.args import\
     add_usual_input_args, add_usual_output_args, anno_id,\
@@ -142,7 +142,7 @@ def config_argparser(parser):
                               nargs='+',
                               help='eg. stac_39819045 stac_98871771')
     parser_mutex.add_argument('--turns',
-                              metavar='TURN_ID', type=parse_turn_id,
+                              metavar='TURN_ID', type=TurnId.from_string,
                               nargs=2,
                               help='eg. 187 192')
     add_commit_args(parser)

--- a/educe/stac/edit/cmd/nudge_dialogue.py
+++ b/educe/stac/edit/cmd/nudge_dialogue.py
@@ -13,7 +13,7 @@ import sys
 from educe.annotation import Span
 import educe.stac as st
 
-from educe.stac.annotation import parse_turn_id
+from educe.stac.annotation import TurnId
 from educe.stac.util.annotate import show_diff, annotate_doc
 from educe.stac.util.args import\
     add_usual_input_args, add_usual_output_args,\
@@ -152,7 +152,7 @@ def config_argparser(parser):
     add_usual_input_args(parser, doc_subdoc_required=True)
     add_usual_output_args(parser, default_overwrite=True)
     add_commit_args(parser)
-    parser.add_argument('turn', metavar='TURN', type=parse_turn_id,
+    parser.add_argument('turn', metavar='TURN', type=TurnId.from_string,
                         help='turn number')
     parser.add_argument('direction', choices=["up", "down"],
                         help='move turn up or down')

--- a/educe/stac/edit/cmd/split_dialogue.py
+++ b/educe/stac/edit/cmd/split_dialogue.py
@@ -15,7 +15,7 @@ import sys
 from educe.annotation import Span
 import educe.stac as st
 
-from educe.stac.annotation import parse_turn_id
+from educe.stac.annotation import TurnId
 from educe.stac.util.annotate import show_diff, annotate_doc
 from educe.stac.util.args import (add_usual_input_args, add_usual_output_args,
                                   add_commit_args,
@@ -119,7 +119,7 @@ def config_argparser(parser):
     add_usual_input_args(parser, doc_subdoc_required=True)
     add_usual_output_args(parser, default_overwrite=True)
     add_commit_args(parser)
-    parser.add_argument('turn', metavar='TURN', type=parse_turn_id,
+    parser.add_argument('turn', metavar='TURN', type=TurnId.from_string,
                         help='turn number')
     parser.set_defaults(func=main)
 


### PR DESCRIPTION
This PR introduces a proper class for turn identifiers in the STAC corpus.

Having a dedicated class enables the definition (and hence encapsulation) of proper conversion methods from/to string:
```python
tid_str = '51.0.2'
tid = TurnId.from_string(tid_str)
str(tid) == tid_str  # evaluates to True
```