### PR TITLE
FIX 'stac-edit move' more robust to trailing whitespace

### DIFF
--- a/educe/stac/edit/cmd/move.py
+++ b/educe/stac/edit/cmd/move.py
@@ -114,7 +114,7 @@ def main(args):
                 renames, src_doc, tgt_doc,
                 end,  # src_split
                 tgt_split=-1)
-        elif end == src_doc.text_span().char_end:
+        elif end == len(src_doc.text()):  # src_doc.text_span().char_end:
             # move down
             # move_portion inserts src_doc[0:src_split] between
             # tgt_doc[0:tgt_split] and tgt_doc[tgt_split:],


### PR DESCRIPTION
This PR introduces a few changes to nudge the span of annotations on the fly if required.

This enables "stac-edit move" to handle dialogues that span the trailing whitespace of the subdoc text.
We really need to come up with a functional convention for the status of whitespaces around dialogues (not that we haven't tried to...).