### PR TITLE
FIX keep turn ids as strings in numpy arrays

### DIFF
--- a/educe/stac/oneoff/weave.py
+++ b/educe/stac/oneoff/weave.py
@@ -771,7 +771,8 @@ def shift_dialogues(doc_src, doc_res, updates, gen):
         # dialogue
         turns_src = sorted((x for x in doc_src.units if is_turn(x)),
                            key=lambda x: x.span)
-        turns_src_tid = np.array([turn_id(x) for x in turns_src])
+        turns_src_tid = np.array([x.features['Identifier']
+                                  for x in turns_src])
         turns_src_beg = np.array([x.span.char_start for x in turns_src])
         turns_src_end = np.array([x.span.char_end for x in turns_src])
         # * locate game turns (index of first and last turn)
@@ -788,7 +789,8 @@ def shift_dialogues(doc_src, doc_res, updates, gen):
         # dialogue
         turns_res = sorted((x for x in doc_res.units if is_turn(x)),
                            key=lambda x: x.span)
-        turns_res_tid = np.array([turn_id(x) for x in turns_res])
+        turns_res_tid = np.array([x.features['Identifier']
+                                  for x in turns_res])
         turns_res_beg = np.array([x.span.char_start for x in turns_res])
         turns_res_end = np.array([x.span.char_end for x in turns_res])
         # align dialogue spans with turn spans
@@ -993,11 +995,12 @@ def hollow_out_missing_turn_text(src_doc, tgt_doc,
 
     # we can't use the API one until we update it to account for the
     # fancy new identifiers
-    tgt_turns = set(turn_id(x) for x in units_tgt
-                    if turn_id(x) is not None)
+    tgt_turns = set(x.features['Identifier']
+                    for x in units_tgt
+                    if x.features.get('Identifier'))
     np_spans = [x.text_span() for x in units_src
-                if (turn_id(x) is not None and
-                    turn_id(x) not in tgt_turns)]
+                if (x.features.get('Identifier') and
+                    x.features['Identifier'] not in tgt_turns)]
 
     # merge consecutive nonplayer turns
     merged_np_spans = []


### PR DESCRIPTION
This PR reverts some of the changes in #119 that broke the weaving procedure.
In the context of numpy arrays, we avoid using the `TurnId` type and use their string version instead.

`TurnId` is defined as a subclass of `tuple` and, when given a list of tuples of the same length, the numpy array creation function automatically creates a multi-dimensional array of basic values instead of a single-dimensional array of multi-dimensional (tuple) values.
This break assumptions of subsequent code, resulting in errors such as this:
```
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```
