### PR TITLE
FIX declare Sequence relation in STAC

### DIFF
--- a/educe/stac/annotation.py
+++ b/educe/stac/annotation.py
@@ -95,6 +95,7 @@ SUBORDINATING_RELATIONS = [
 COORDINATING_RELATIONS = [
     'Result',
     'Narration',
+    'Sequence',  # alt name for Narration
     'Continuation',
     'Contrast',
     'Parallel',


### PR DESCRIPTION
This PR adds the Sequence relation (as an alternative name to Narration) that is widely used in the STAC situated data.