### PR TITLE
ENH spread use of nary_enc in RST trees and functions from/to them

### DIFF
--- a/educe/rst_dt/corpus.py
+++ b/educe/rst_dt/corpus.py
@@ -17,7 +17,7 @@ from educe.rst_dt import parse
 import educe.util
 import educe.corpus
 from .document_plus import DocumentPlus
-from .annotation import SimpleRSTTree, _binarize
+from .annotation import SimpleRSTTree
 from .deptree import RstDepTree
 from .pseudo_relations import rewrite_pseudo_rels
 
@@ -121,7 +121,7 @@ class RstDtParser(object):
         If True, relation labels are converted to their coarse-grained
         equivalent.
 
-    nary_conv : string, optional
+    nary_enc : string, optional
         Conversion method from constituency to dependency tree, for
         n-ary spans, n > 2, whose kids are all nuclei:
         'tree' picks the leftmost nucleus as the head of all the others
@@ -146,7 +146,7 @@ class RstDtParser(object):
 
     def __init__(self, corpus_dir, args, coarse_rels=False,
                  fix_pseudo_rels=False,
-                 nary_conv='chain',
+                 nary_enc='chain',
                  nuc_in_label=False,
                  exclude_file_docs=False):
         self.reader = Reader(corpus_dir)
@@ -166,10 +166,10 @@ class RstDtParser(object):
         else:
             self.rel_conv = None
         # how to convert n-ary spans
-        self.nary_conv = nary_conv
-        if nary_conv not in ['chain', 'tree']:
+        self.nary_enc = nary_enc
+        if nary_enc not in ['chain', 'tree']:
             err_msg = 'Unknown conversion for n-ary spans: {}'
-            raise ValueError(err_msg.format(nary_conv))
+            raise ValueError(err_msg.format(nary_enc))
         # whether nuclearity should be part of the label
         self.nuc_in_label = nuc_in_label
 
@@ -222,14 +222,8 @@ class RstDtParser(object):
         # end TO DEPRECATE
 
         # convert to dep tree
-        # WIP
-        if self.nary_conv == 'chain':
-            # legacy mode, through SimpleRSTTree
-            # deptree = RstDepTree.from_simple_rst_tree(rsttree)
-            # modern mode, directly from a binarized RSTTree
-            deptree = RstDepTree.from_rst_tree(_binarize(orig_rsttree))
-        else:  # tree conversion
-            deptree = RstDepTree.from_rst_tree(orig_rsttree)
+        deptree = RstDepTree.from_rst_tree(orig_rsttree,
+                                           nary_enc=self.nary_enc)
         # end WIP
         doc.deptree = deptree
 

--- a/educe/rst_dt/learning/cmd/extract.py
+++ b/educe/rst_dt/learning/cmd/extract.py
@@ -94,6 +94,11 @@ def config_argparser(parser):
     parser.add_argument('--experimental', action='store_true',
                         help='Enable experimental features '
                              '(currently none)')
+    # 2016-09-12 nary_enc: chain vs tree transform
+    parser.add_argument('--nary_enc', default='chain',
+                        choices=['chain', 'tree'],
+                        help='Encoding for n-ary nodes')
+    # end nary_enc
     parser.set_defaults(func=main)
 
 
@@ -117,6 +122,7 @@ def main(args):
     rst_reader = RstDtParser(args.corpus, args,
                              coarse_rels=args.coarse,
                              fix_pseudo_rels=args.fix_pseudo_rels,
+                             nary_enc=args.nary_enc,
                              exclude_file_docs=exclude_file_docs)
     rst_corpus = rst_reader.corpus
     # TODO: change educe.corpus.Reader.slurp*() so that they return an object


### PR DESCRIPTION
This PR introduces the `nary_enc` parameter and attribute to RST trees and functions from/to them.

It specifies how n-ary nodes in the original RST trees are encoded into binary trees.
Its possible values are currently `{'tree', 'chain'}` ; it subsumes and replaces `nary_conv`.