### PR TITLE
ENH param lbl_type in RstDeptree.get_dependencies()

### DIFF
--- a/educe/rst_dt/deptree.py
+++ b/educe/rst_dt/deptree.py
@@ -221,17 +221,31 @@ class RstDepTree(object):
             # common rank
             self.ranks[_idx_dep] = rank
 
-    def get_dependencies(self):
+    def get_dependencies(self, lbl_type='rel'):
         """Get the list of dependencies in this dependency tree.
 
         Each dependency is a 3-uple (gov, dep, label),
         gov and dep being EDUs.
+
+        Parameters
+        ----------
+        lbl_type: one of {'rel', 'rel+nuc'} (TODO 'rel+nuc+rnk'?)
+            Type of the labels.
         """
+        if lbl_type not in ['rel', 'rel+nuc']:
+            raise ValueError("lbl_type needs to be one of {'rel', 'rel+nuc'}")
+
         edus = self.edus
 
         deps = self.edus[1:]
         gov_idxs = self.heads[1:]
-        labels = self.labels[1:]
+        if lbl_type == 'rel':
+            labels = self.labels[1:]
+        elif lbl_type == 'rel+nuc':
+            labels = list(zip(self.labels[1:],
+                              ['N' + nuc[0] for nuc in self.nucs[1:]]))
+        else:
+            raise NotImplementedError("WIP")
 
         result = [(edus[gov_idx], dep, lbl)
                   for gov_idx, dep, lbl

--- a/educe/rst_dt/document_plus.py
+++ b/educe/rst_dt/document_plus.py
@@ -412,13 +412,19 @@ class DocumentPlus(object):
                      if epair[0] != epair[1]]
         return all_pairs
 
-    def relations(self, edu_pairs):
+    def relations(self, edu_pairs, lbl_type='rel'):
         """Get the relation that holds in each of the edu_pairs.
+
+        As of 2016-09-30, this function has a unique caller:
+        doc_vectorizer.DocumentLabelExtractor._extract_labels() .
 
         Parameters
         ----------
         edu_pairs : [(DU, DU)]
             List of DU pairs.
+
+        lbl_type : one of {'rel', 'rel+nuc'}
+            Type of label.
 
         Returns
         -------
@@ -429,7 +435,8 @@ class DocumentPlus(object):
             return [None for epair in edu_pairs]
 
         rels = {(src, tgt): rel
-                for src, tgt, rel in self.deptree.get_dependencies()}
+                for src, tgt, rel
+                in self.deptree.get_dependencies(lbl_type=lbl_type)}
         erels = [rels.get(epair, 'UNRELATED')
                  for epair in edu_pairs]
         return erels


### PR DESCRIPTION
This PR adds a parameter `lbl_type` to `RstDepTree.get_dependencies()`.

It enables to specify the labelling function used when listing the dependencies from a dtree, as the relation name alone or relation name and nuclearity.