### PR TITLE
DOC+ENH toggle between {un,}ordered pairs of EDUs, same_unit candidates

### DIFF
--- a/educe/learning/edu_input_format.py
+++ b/educe/learning/edu_input_format.py
@@ -103,7 +103,13 @@ def labels_comment(class_mapping):
 
 
 def _load_labels(f):
-    """Actually read the label set"""
+    """Actually read the label set.
+
+    Parameters
+    ----------
+    f : str
+        Features file, whose first line is a comment with the list of labels.
+    """
     line = f.readline()
     seq = line[1:].split()[1:]
     labels = {lbl: idx for idx, lbl in enumerate(seq, start=1)}
@@ -112,34 +118,43 @@ def _load_labels(f):
 
 
 def load_labels(f):
-    """Read label set (from a features file) into a dictionary mapping labels
-    to indices and index"""
+    """Read label set into a dictionary mapping labels to indices"""
     with codecs.open(f, 'r', 'utf-8') as f:
         return _load_labels(f)
 
 
 def dump_all(X_gen, y_gen, f, class_mapping, docs, instance_generator):
-    """Dump a whole dataset: features (in svmlight) and EDU pairs
+    """Dump a whole dataset: features (in svmlight) and EDU pairs.
 
-    class_mapping is a mapping from label to int
+    Parameters
+    ----------
+    X_gen : iterable of int arrays
+        Feature vectors.
 
-    :type X_gen: iterable of int arrays
-    :type y_gen: iterable of int
-    :param f: output features file path
-    :param class_mapping: dict(string, int)
-    :param instance_generator: function that returns an iterable
-                               of pairs given a document
+    y_gen : iterable of int
+        Ground truth labels.
+
+    f : str
+        Output features file path
+
+    class_mapping : dict(str, int)
+        Mapping from label to int.
+
+    docs : list of DocumentPlus
+        Documents
+
+    instance_generator : function from doc to iterable of pairs
+        TODO
     """
-    # the labelset will be written in a comment at the beginning of the
-    # svmlight file
-    comment = labels_comment(class_mapping)
-
-    # dump: EDUs, pairings, vectorized pairings with label
+    # dump EDUs
     edu_input_file = f + '.edu_input'
     dump_edu_input_file(docs, edu_input_file)
-
+    # dump EDU pairings
     pairings_file = f + '.pairings'
     dump_pairings_file((instance_generator(doc) for doc in docs),
                        pairings_file)
-
+    # dump vectorized pairings with label
+    # the labelset will be written in a comment at the beginning of the
+    # svmlight file
+    comment = labels_comment(class_mapping)
     dump_svmlight_file(X_gen, y_gen, f, comment=comment)

--- a/educe/learning/keygroup_vectorizer.py
+++ b/educe/learning/keygroup_vectorizer.py
@@ -18,14 +18,14 @@ class KeyGroupVectorizer(object):
     def __init__(self):
         self.vocabulary_ = None  # FIXME should be set in fit()
 
-    def _count_vocab(self, vectors, fixed_vocab):
+    def _count_vocab(self, vectors, fixed_vocab=False):
         """Create sparse feature matrix and vocabulary.
 
         Parameters
         ----------
-        vectors : ?
+        vectors : list of KeyGroup
             List of feature vectors, one vector per sample.
-        fixed_vocab : boolean
+        fixed_vocab : boolean, defaults to False
             If True, use the vocabulary that hopefully has already been
             set during `fit()`.
 

--- a/educe/rst_dt/learning/cmd/extract.py
+++ b/educe/rst_dt/learning/cmd/extract.py
@@ -99,6 +99,11 @@ def config_argparser(parser):
                         choices=['chain', 'tree'],
                         help='Encoding for n-ary nodes')
     # end nary_enc
+    # 2016-09-30 enable to choose between unordered and ordered pairs
+    parser.add_argument('--unordered_pairs',
+                        action='store_true',
+                        help=("Instances are unordered pairs: "
+                              "(src, tgt) == (tgt, src)"))
     parser.set_defaults(func=main)
 
 
@@ -206,7 +211,8 @@ def main(args):
     # to iterate over a stable (sorted) list of FileIds
     docs = [open_plus(doc) for doc in sorted(rst_corpus)]
     # instance generator
-    instance_generator = lambda doc: doc.all_edu_pairs()
+    ordered_pairs = not args.unordered_pairs  # 2016-09-30
+    instance_generator = lambda doc: doc.all_edu_pairs(ordered=ordered_pairs)
     split_feat_space = 'dir_sent'
     # extract vectorized samples
     if args.vocabulary is not None:
@@ -231,6 +237,7 @@ def main(args):
     elif args.labels is not None:
         labelset = load_labels(args.labels)
         labtor = DocumentLabelExtractor(instance_generator,
+                                        ordered_pairs=ordered_pairs,
                                         labelset=labelset)
         labtor.fit(docs)
         y_gen = labtor.transform(docs)


### PR DESCRIPTION
This PR adds a parameter that enables to choose between ordered and unordered pairs of EDUs, and a helper to generate same_unit candidates (RST).