### PR TITLE
FIX remove local path to stac data

### DIFF
--- a/docs/stac-stats-situated.ipynb
+++ b/docs/stac-stats-situated.ipynb
@@ -8,7 +8,9 @@
    },
    "outputs": [],
    "source": [
-    "from educe.stac.util.situated_stats import *"
+    "from educe.stac.util.situated_stats import *\n",
+    "# edit with your own local path to the STAC data\n",
+    "STAC_DATA_DIR = '/home/mmorey/melodi/stac/svn-stac/data'"
    ]
   },
   {
@@ -21,51 +23,78 @@
      "output_type": "stream",
      "text": [
       "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season2/s2-league5-game1\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season2/s2-league5-game0\n",
+      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season2/s2-league5-game0\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/mmorey/melodi/educe/educe/stac/util/situated_stats.py:514: UserWarning: s2-league5-game0 [01] discourse GOLD: relation s2-league5-game0_01_nasher_1498484092775 has no Argument_scope\n",
+      "  warnings.warn(w_msg)\n",
+      "/home/mmorey/melodi/educe/educe/stac/util/situated_stats.py:514: UserWarning: s2-league5-game0 [01] discourse GOLD: relation s2-league5-game0_01_nasher_1498484095959 has no Argument_scope\n",
+      "  warnings.warn(w_msg)\n",
+      "/home/mmorey/melodi/educe/educe/stac/util/situated_stats.py:514: UserWarning: s2-league5-game0 [01] discourse GOLD: relation s2-league5-game0_01_nasher_1498484097967 has no Argument_scope\n",
+      "  warnings.warn(w_msg)\n",
+      "/home/mmorey/melodi/educe/educe/stac/util/situated_stats.py:514: UserWarning: s2-league5-game0 [01] discourse GOLD: relation s2-league5-game0_01_nasher_1498484100468 has no Argument_scope\n",
+      "  warnings.warn(w_msg)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season2/s2-league5-game3\n",
       "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season2/s2-league5-game5\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/pilot/pilot04\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/pilot/pilot01\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/pilot/pilot21\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/pilot/pilot03\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/TEST/pilot02\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season1/s1-league2-game1\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season1/s1-league2-game3\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season1/s1-league2-game2\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season1/s1-league2-game4\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season2/s2-league8-game1\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season1/s1-league1-game2\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season1/s1-league1-game3\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season2/s2-leagueM-game3\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season1/s1-league1-game1\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season2/s2-leagueM-game5\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/TEST/s2-leagueM-game4\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season1/s1-league1-game4\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season2/s2-league4-game3\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season1/s1-league3-game4\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season1/s1-league3-game5\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season1/s1-league3-game6\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season1/s1-league3-game7\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season1/s1-league3-game1\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season1/s1-league3-game2\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/TEST/s1-league3-game3\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season2/s2-practice2\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/pilot/pilot14\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/pilot/pilot20\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season2/s2-leagueM-game2\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season2/s2-league4-game1\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/TEST/s2-league4-game2\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season2/s2-league3-game1\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season1/s1-league1-game5\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season2/s2-league1-game1\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season2/s2-league3-game5\n",
-      "/home/mmorey/melodi/stac/svn-stac/data/situated-annotation/socl-season2/s2-league3-game4\n"
+      "source    s2-league5-game5_05_stac_1498119535\n",
+      "target    s2-league5-game5_05_stac_1458309150\n",
+      "type                                 Sequence\n",
+      "Name: 380, dtype: object\n",
+      "tgt Empty DataFrame\n",
+      "Columns: [global_id, doc, subdoc, stage, annotator, type, span_beg, span_end, text, creation_date, author, last_modif_date, last_modifier, seg_idx, eeu_idx, edu_idx, turn_id, turn_span_beg, turn_span_end]\n",
+      "Index: []\n",
+      "src                                global_id               doc subdoc      stage  \\\n",
+      "489  s2-league5-game5_05_stac_1498119535  s2-league5-game5     05  discourse   \n",
+      "\n",
+      "    annotator              type  span_beg  span_end  \\\n",
+      "489      GOLD  NonplayerSegment      4032      4060   \n",
+      "\n",
+      "                             text creation_date author last_modif_date  \\\n",
+      "489  gramos will move the robber.    1498119535   stac               0   \n",
+      "\n",
+      "    last_modifier  seg_idx  eeu_idx  edu_idx  turn_id  turn_span_beg  \\\n",
+      "489           n/a      489    397.0      NaN  185.0.1             19   \n",
+      "\n",
+      "     turn_span_end  \n",
+      "489             47  \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/mmorey/melodi/educe/educe/stac/util/situated_stats.py:514: UserWarning: s2-league5-game0 [01] discourse GOLD: relation s2-league5-game0_01_nasher_1498484103784 has no Argument_scope\n",
+      "  warnings.warn(w_msg)\n"
+     ]
+    },
+    {
+     "ename": "IndexError",
+     "evalue": "index 0 is out of bounds for axis 0 with size 0",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-2-fe1b64e0f4e2>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m turns_situ, dlgs_situ, segs_situ, acts_situ, schms_situ, schm_mbrs_situ, rels_situ, res_situ, pref_situ = read_corpus_as_dataframes(\n\u001b[0;32m----> 2\u001b[0;31m     STAC_DATA_DIR, version='situated', split='all', strip_cdus=True, attach_len=True)\n\u001b[0m",
+      "\u001b[0;32m/home/mmorey/melodi/educe/educe/stac/util/situated_stats.py\u001b[0m in \u001b[0;36mread_corpus_as_dataframes\u001b[0;34m(stac_data_dir, version, split, strip_cdus, attach_len, sel_games, exc_games)\u001b[0m\n\u001b[1;32m    659\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    660\u001b[0m         game_dfs = read_game_as_dataframes(\n\u001b[0;32m--> 661\u001b[0;31m             game_folder, strip_cdus=strip_cdus, attach_len=attach_len)\n\u001b[0m\u001b[1;32m    662\u001b[0m         \u001b[0mturn_dfs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mappend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mgame_dfs\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    663\u001b[0m         \u001b[0mdlg_dfs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mappend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mgame_dfs\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/home/mmorey/melodi/educe/educe/stac/util/situated_stats.py\u001b[0m in \u001b[0;36mread_game_as_dataframes\u001b[0;34m(game_folder, sel_annotator, thorough, strip_cdus, attach_len)\u001b[0m\n\u001b[1;32m    571\u001b[0m     \u001b[0;31m# * length of attachments\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    572\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mstrip_cdus\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mattach_len\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 573\u001b[0;31m         \u001b[0mdf_rels\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcompute_rel_attributes\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdf_segs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdf_rels\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    574\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    575\u001b[0m     return (df_turns, df_dlgs, df_segs, df_acts, df_schms, df_schm_mbrs,\n",
+      "\u001b[0;32m/home/mmorey/melodi/educe/educe/stac/util/situated_stats.py\u001b[0m in \u001b[0;36mcompute_rel_attributes\u001b[0;34m(seg_df, rel_df)\u001b[0m\n\u001b[1;32m    189\u001b[0m             \u001b[0;31m# compute length of attachment\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    190\u001b[0m             \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 191\u001b[0;31m                 len_seg = (seg_tgt['seg_idx'].values[0] -\n\u001b[0m\u001b[1;32m    192\u001b[0m                            seg_src['seg_idx'].values[0])\n\u001b[1;32m    193\u001b[0m             \u001b[0;32mexcept\u001b[0m \u001b[0mIndexError\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mIndexError\u001b[0m: index 0 is out of bounds for axis 0 with size 0"
      ]
     }
    ],
    "source": [
     "turns_situ, dlgs_situ, segs_situ, acts_situ, schms_situ, schm_mbrs_situ, rels_situ, res_situ, pref_situ = read_corpus_as_dataframes(\n",
-    "    version='situated', split='all', strip_cdus=True, attach_len=True)"
+    "    STAC_DATA_DIR, version='situated', split='all', strip_cdus=True, attach_len=True)"
    ]
   },
   {
@@ -121,7 +150,9 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# print(dlgs_situ[:5])"
@@ -180,7 +211,9 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# print(acts_situ[:5])"
@@ -189,7 +222,9 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# print(schms_situ[:5])"
@@ -198,7 +233,9 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# print(schm_mbrs_situ[:5])"
@@ -257,7 +294,9 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# print(res_situ[:5])"
@@ -266,7 +305,9 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# print(pref_situ[:5])"
@@ -375,7 +416,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# turns_spect, dlgs_spect, segs_spect, acts_spect, schms_spect, schm_mbrs_spect, rels_spect, res_spect, pref_spect = read_corpus_as_dataframes(version='ling', split='all', sel_games=games_situ)"

--- a/educe/stac/util/situated_stats.py
+++ b/educe/stac/util/situated_stats.py
@@ -21,9 +21,6 @@ from educe.stac.corpus import Reader as StacReader
 from educe.stac.graph import Graph
 
 
-# local path
-STAC_DATA_DIR = '/home/mmorey/melodi/stac/svn-stac/data'
-
 # naming schemes for games in each season
 GAME_GLOBS = {
     'pilot': ['pilot*'],
@@ -579,13 +576,15 @@ def read_game_as_dataframes(game_folder, sel_annotator=None, thorough=True,
             df_rels, df_res, df_pref)
 
 
-def read_corpus_as_dataframes(version='situated', split='all',
+def read_corpus_as_dataframes(stac_data_dir, version='situated', split='all',
                               strip_cdus=False, attach_len=False,
                               sel_games=None, exc_games=None):
     """Read the entire corpus as dataframes.
 
     Parameters
     ----------
+    stac_data_dir : str
+        Path to the STAC data folder, eg. `/path/to/stac/svn/data`.
     version : one of {'ling', 'situated'}, defaults to 'situated'
         Version of the corpus we want to examine.
     split : one of {'all', 'train', 'test'}, defaults to 'all'
@@ -625,7 +624,7 @@ def read_corpus_as_dataframes(version='situated', split='all',
     else:
         sel_globs = all_globs['TEST']
 
-    sel_globs = [os.path.join(STAC_DATA_DIR, base_dir, x) for x in sel_globs]
+    sel_globs = [os.path.join(stac_data_dir, base_dir, x) for x in sel_globs]
     game_folders = list(chain.from_iterable(glob(x) for x in sel_globs))
     # map games to their folders
     game_dict = {os.path.basename(x): x for x in game_folders}


### PR DESCRIPTION
This PR replaces a local path to the STAC data with a function parameter.

Its value must be set in the jupyter notebook by the user, according to their own installation.
NB: this is a quick and dirty fix ; the values in the notebook are incomplete because I ran it on an unstable version of the STAC data. I'll replace this with a "correct" version ASAP.