### PR TITLE
ENH dump RST-DT corpus as disdep files

### DIFF
--- a/educe/rst_dt/disdep_format.py
+++ b/educe/rst_dt/disdep_format.py
@@ -1,0 +1,79 @@
+"""Dependency format for RST discourse trees.
+
+One line per EDU.
+"""
+
+from __future__ import absolute_import, print_function
+import codecs
+import csv
+import os
+
+from educe.rst_dt.corpus import RELMAP_112_18_FILE, RstRelationConverter
+
+RELCONV = RstRelationConverter(RELMAP_112_18_FILE).convert_label
+
+
+def _dump_disdep_file(rst_deptree, f):
+    """Actually do dump"""
+    writer = csv.writer(f, dialect=csv.excel_tab)
+
+    # 0 is the fake root, there is no point in writing its info
+    edus = rst_deptree.edus[1:]
+    heads = rst_deptree.heads[1:]
+    labels = rst_deptree.labels[1:]
+    nucs = rst_deptree.nucs[1:]
+    ranks = rst_deptree.ranks[1:]
+
+    for i, (edu, head, label, nuc, rank) in enumerate(
+            zip(edus, heads, labels, nucs, ranks), start=1):
+        # text of EDU ; some EDUs have newlines in their text, so convert
+        # those to simple spaces
+        txt = edu.text().replace('\n', ' ')
+        clabel = RELCONV(label)
+        writer.writerow([i, txt, head, label, clabel, nuc, rank])
+
+
+def dump_disdep_file(rst_deptree, f):
+    """Dump dependency RST tree to a disdep file.
+
+    Parameters
+    ----------
+    rst_deptree : RstDepTree
+        RST dependency tree.
+    f : str
+        Path of the output file.
+    """
+    with codecs.open(f, 'wb', 'utf-8') as f_out:
+        _dump_disdep_file(rst_deptree, f_out)
+
+
+def dump_disdep_files(rst_deptrees, out_dir):
+    """Dump dependency RST trees to a folder.
+
+    This creates one file per RST tree, plus a metadata file that
+    specifies the encoding of n-ary relations and the mapping from
+    fine-grained relation labels to their classes.
+
+    Parameters
+    ----------
+    rst_deptrees : list of RstDepTree
+        RST dependency trees, one per document.
+    out_dir : str
+        Path to the output folder.
+    """
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+
+    # metadata file
+    nary_encs = [x.nary_enc for x in rst_deptrees]
+    assert len(set(nary_encs)) == 1
+    nary_enc = nary_encs[0]
+    f_meta = os.path.join(out_dir, 'metadata')
+    with codecs.open(f_meta, mode='w', encoding='utf-8') as f_meta:
+        print('nary_enc: {}'.format(nary_enc), file=f_meta)
+        print('relmap: {}'.format(RELMAP_112_18_FILE), file=f_meta)
+    # deptrees, one file per doc
+    for rst_deptree in rst_deptrees:
+        doc_name = rst_deptree.origin.doc
+        f_doc = os.path.join(out_dir, '{}.dis_dep'.format(doc_name))
+        dump_disdep_file(rst_deptree, f_doc)

--- a/educe/rst_dt/util/cmd/rstdt_to_deps.py
+++ b/educe/rst_dt/util/cmd/rstdt_to_deps.py
@@ -1,0 +1,73 @@
+"""This module converts the RST-DT corpus to dependency trees.
+
+"""
+from __future__ import absolute_import, print_function
+
+import argparse
+import os
+
+from educe.rst_dt.corpus import Reader
+from educe.rst_dt.deptree import RstDepTree
+from educe.rst_dt.rst_wsj_corpus import TRAIN_FOLDER, TEST_FOLDER
+from educe.rst_dt.disdep_format import dump_disdep_files
+
+
+def dump_dep_rstdt(corpus_dir, out_dir, nary_enc):
+    """Convert and dump the RST-DT corpus as dependency trees."""
+    # convert and dump RST trees from train
+    dir_train = os.path.join(corpus_dir, TRAIN_FOLDER)
+    if not os.path.isdir(dir_train):
+        raise ValueError('No such folder: {}'.format(dir_train))
+    reader_train = Reader(dir_train)
+    trees_train = reader_train.slurp()
+    dtrees_train = {doc_name: RstDepTree.from_rst_tree(rst_tree,
+                                                       nary_enc=nary_enc)
+                    for doc_name, rst_tree in trees_train.items()}
+    dump_disdep_files(dtrees_train.values(),
+                      os.path.join(out_dir, os.path.basename(dir_train)))
+
+    # convert and dump RST trees from test
+    dir_test = os.path.join(corpus_dir, TEST_FOLDER)
+    if not os.path.isdir(dir_test):
+        raise ValueError('No such folder: {}'.format(dir_test))
+    reader_test = Reader(dir_test)
+    trees_test = reader_test.slurp()
+    dtrees_test = {doc_name: RstDepTree.from_rst_tree(rst_tree,
+                                                      nary_enc=nary_enc)
+                   for doc_name, rst_tree in trees_test.items()}
+    dump_disdep_files(dtrees_test.values(),
+                      os.path.join(out_dir, os.path.basename(dir_test)))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Export a dependency version of the RST-DT corpus.'
+    )
+    # TODO obtain corpus_dir through a global(?) variable elsewhere, eg.
+    # in the educe.rst_dt module ; the idea is to have a central place
+    # to gather this info so it's accessible for the various utilities
+    parser.add_argument('--corpus_dir',
+                        default=os.path.join(
+                            os.path.expanduser('~'),  # user home
+                            'corpora', 'rst-dt',
+                            'rst_discourse_treebank/data'
+                        ),
+                        help='Base folder of the corpus')
+    # TODO ibid, although what would make a "good" mechanism to access
+    # a "good" default value is less clear in this instance
+    parser.add_argument('--out_dir',
+                        default=os.path.join(
+                            os.path.expanduser('~'),  # user home
+                            'melodi/irit-rst-dt',
+                            'TMP_disdep_chain_true'
+                        ),
+                        help='Output folder')
+    # 'chain' corresponds to the de facto standard setting in the
+    # evaluation of RST parsers in the literature, but 'tree' enables
+    # lossless roundtrips between c-trees and head-ordered d-trees
+    parser.add_argument('--nary_enc',
+                        default='chain',
+                        choices=['chain', 'tree'],
+                        help='Encoding of n-ary nodes')
+    args = parser.parse_args()
+    dump_dep_rstdt(args.corpus_dir, args.out_dir, args.nary_enc)


### PR DESCRIPTION
Dumper for the RST-DT corpus as a set of .disdep files (one per doc) plus a metadata file containing the n-ary encoding and the local path to the mapping from RST relations to their class.